### PR TITLE
fix(M2): close blockers #8-#12 — event bus, validation, needs_review, HTTP tests

### DIFF
--- a/inv/api/deps.py
+++ b/inv/api/deps.py
@@ -1,24 +1,48 @@
-"""FastAPI dependency injection helpers."""
+"""FastAPI dependency injection helpers.
+
+The app caches a single SQLAlchemy engine on ``app.state`` so every
+request reuses the same connection pool. The alternative (creating an
+engine per request) duplicates the Engine-class event listener on every
+call and also makes test isolation impossible because ``get_settings``
+re-reads environment variables on each dependency resolution.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Generator
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Request
+from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from inv.settings import Settings, get_settings
+from inv.settings import Settings
 from inv.storage.db import init_engine
 from inv.storage.repositories import ItemRepository, LocationRepository, MovementRepository
 
 
-def get_session(settings: Annotated[Settings, Depends(get_settings)]) -> Generator[Session, None, None]:
-    """Dependency: get a database session.
+def get_settings_from_app(request: Request) -> Settings:
+    """Return the :class:`Settings` bound to this app instance.
 
-    Each request gets a fresh session that's closed after the request.
+    Populated by :func:`inv.main.create_app`. Tests can override this
+    dependency via ``app.dependency_overrides`` or just create the app
+    with different settings — state is never read from the environment
+    at request time.
     """
-    engine = init_engine(settings)
+    settings: Settings = request.app.state.settings
+    return settings
+
+
+def get_engine(request: Request) -> Engine:
+    """Return the app-scoped SQLAlchemy engine."""
+    engine: Engine = request.app.state.engine
+    return engine
+
+
+def get_session(
+    engine: Annotated[Engine, Depends(get_engine)],
+) -> Generator[Session, None, None]:
+    """Per-request SQLAlchemy session (the engine is app-scoped)."""
     SessionLocal = sessionmaker(bind=engine)
     session = SessionLocal()
     try:
@@ -44,3 +68,15 @@ def get_movement_repository(
 ) -> MovementRepository:
     """Dependency: MovementRepository bound to the request session."""
     return MovementRepository(session)
+
+
+# Re-exported for backwards compat; init_engine is still the real entrypoint.
+__all__ = [
+    "get_engine",
+    "get_item_repository",
+    "get_location_repository",
+    "get_movement_repository",
+    "get_session",
+    "get_settings_from_app",
+    "init_engine",
+]

--- a/inv/api/routes_scan.py
+++ b/inv/api/routes_scan.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-from starlette.templating import _TemplateResponse
 
 from inv.api.deps import get_session
 from inv.core.services import (
@@ -22,38 +21,30 @@ router = APIRouter(prefix="", tags=["scan"])
 
 
 class ScanRequest(BaseModel):
-    """Request body for POST /scan."""
+    """Request body for POST /scan.
 
-    gtin: str
-    direction: str = "IN"  # IN, OUT, ADJUST
-    qty_multiplier: int = 1
-    location_id: int = 1
-    actor: str | None = None
-    note: str | None = None
+    Validation rules:
+    - ``gtin`` must be between 6 and 14 characters (UPC-E up to GTIN-14).
+      Non-digit content is allowed at this layer so future barcode
+      symbologies (Code 128, ISBN-X) can pass through; strict GTIN-13
+      check-digit validation is a separate concern.
+    - ``direction`` is a strict enum — invalid values are rejected by
+      Pydantic with a 422 instead of falling through to the DB's CHECK
+      constraint.
+    - ``qty_multiplier`` must be positive. Down-adjustments are a V2
+      concern handled with signed-ADJUST tooling.
+    """
 
-
-class ScanResponseItem(BaseModel):
-    """Item details in scan response."""
-
-    id: int
-    gtin: str
-    name: str | None
-    brand: str | None
-    on_hand: int
-
-
-class ScanResponse(BaseModel):
-    """Response body for POST /scan."""
-
-    success: bool
-    item: ScanResponseItem
-    on_hand: int
-    direction: str
-    message: str
+    gtin: str = Field(..., min_length=6, max_length=14)
+    direction: Literal["IN", "OUT", "ADJUST"] = "IN"
+    qty_multiplier: int = Field(default=1, ge=1)
+    location_id: int = Field(default=1, ge=1)
+    actor: str | None = Field(default=None, max_length=255)
+    note: str | None = Field(default=None, max_length=2000)
 
 
 @router.get("/scan", response_class=HTMLResponse, tags=["web"])
-async def get_scan_page(request: Request) -> _TemplateResponse:
+async def get_scan_page(request: Request) -> HTMLResponse:
     """Render the scan page."""
     return templates.TemplateResponse(request, "scan.html", {})
 
@@ -63,42 +54,16 @@ async def post_scan(
     req: ScanRequest,
     session: Annotated[Session, Depends(get_session)],
     request: Request,
-) -> _TemplateResponse:
+) -> HTMLResponse:
     """Record a barcode scan and update inventory.
 
-    When called with `Accept: application/json`, returns JSON (standard REST).
-    When called with `Accept: text/html` (from HTMX), returns an HTML partial.
+    Returns an HTML partial for HTMX/fetch clients. Errors use standard
+    HTTP status codes with JSON ``{"detail": "..."}`` bodies:
 
-    JSON Request body:
-    ```json
-    {
-        "gtin": "5000112139107",
-        "direction": "IN",
-        "qty_multiplier": 1,
-        "location_id": 1
-    }
-    ```
-
-    JSON Response:
-    ```json
-    {
-        "success": true,
-        "item": {
-            "id": 1,
-            "gtin": "5000112139107",
-            "name": "Coke Classic",
-            "brand": "Coca-Cola",
-            "on_hand": 42
-        },
-        "on_hand": 42,
-        "direction": "IN",
-        "message": "Scanned in 1 × Coke Classic"
-    }
-    ```
-
-    Errors:
     - 404: Location not found
     - 409: Negative stock (OUT direction would drop below 0)
+    - 422: Validation error (bad direction, empty GTIN, non-positive
+           qty_multiplier, etc.) — emitted by Pydantic automatically.
     """
     try:
         result = record_scan(
@@ -114,25 +79,18 @@ async def post_scan(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Location {e.location_id} not found",
-        )
+        ) from e
     except NegativeStockError as e:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(e),
-        )
+        ) from e
 
     # Construct human-readable message
-    verb = (
-        "scanned in"
-        if req.direction == "IN"
-        else "scanned out"
-        if req.direction == "OUT"
-        else "adjusted"
-    )
+    verb = {"IN": "Scanned in", "OUT": "Scanned out", "ADJUST": "Adjusted"}[req.direction]
     item_label = result.item.name or result.item.gtin
-    message = f"{verb.title()} {req.qty_multiplier} × {item_label}"
+    message = f"{verb} {req.qty_multiplier} × {item_label}"
 
-    # Return HTML partial for HTMX clients
     context = {
         "item": result.item,
         "on_hand": result.on_hand,

--- a/inv/core/events.py
+++ b/inv/core/events.py
@@ -1,0 +1,97 @@
+"""In-process event bus signals and their payload schemas.
+
+DEVELOPMENT_PLAN.md §6 locks the signal names and payload shapes down as
+the plugin modularity contract. Core services emit these; plugin modules
+subscribe without ever being imported by core. The signals use ``blinker``
+(in-process pub/sub) so there is no serialization boundary to maintain.
+
+Payload dataclasses are frozen so subscribers can stash them without
+worrying about mutation from later code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from blinker import signal
+
+# ----------------------------------------------------------------------
+# Signals
+# ----------------------------------------------------------------------
+
+#: Fired after a ``movement`` row is committed. Subscribers get a
+#: :class:`MovementCreatedEvent`. Plugins (reporting, central-sync,
+#: webhooks) hook here.
+movement_created = signal("movement.created")
+
+#: Fired the first time an item row is created (from a scan stub, from
+#: the provider chain, or from manual entry). NOT fired on subsequent
+#: upserts/enrichments of the same item.
+item_created = signal("item.created")
+
+#: Fired when an item is enriched by a provider or manually. Plugins
+#: that cache or re-index products subscribe here.
+item_enriched = signal("item.enriched")
+
+#: Fired when a scan's GTIN misses every provider in the lookup chain
+#: and ends up as a ``needs_review`` stub. M3's manual enrichment UX
+#: populates its queue off this signal.
+scan_unknown = signal("scan.unknown")
+
+
+# ----------------------------------------------------------------------
+# Payload schemas (frozen)
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MovementCreatedEvent:
+    """Payload for :data:`movement_created`."""
+
+    movement_id: int
+    item_id: int
+    location_id: int
+    delta: int
+    direction: Literal["IN", "OUT", "ADJUST"]
+    actor: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ItemCreatedEvent:
+    """Payload for :data:`item_created`."""
+
+    item_id: int
+    gtin: str
+    source: str  # "stub", "openfoodfacts", "manual", etc.
+
+
+@dataclass(frozen=True)
+class ItemEnrichedEvent:
+    """Payload for :data:`item_enriched`."""
+
+    item_id: int
+    provider: str
+    fields_filled: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ScanUnknownEvent:
+    """Payload for :data:`scan_unknown`."""
+
+    gtin: str
+    attempted_providers: tuple[str, ...]
+
+
+__all__ = [
+    "ItemCreatedEvent",
+    "ItemEnrichedEvent",
+    "MovementCreatedEvent",
+    "ScanUnknownEvent",
+    "item_created",
+    "item_enriched",
+    "movement_created",
+    "scan_unknown",
+]

--- a/inv/core/services.py
+++ b/inv/core/services.py
@@ -1,16 +1,26 @@
 """Business logic and service layer.
 
 Services orchestrate repositories, emit events, and enforce domain rules.
+All persistence happens inside a single transaction per public service
+call so we never leave the DB half-written on errors.
 """
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from sqlalchemy.orm import Session
 
+from inv.core.events import (
+    ItemCreatedEvent,
+    MovementCreatedEvent,
+    item_created,
+    movement_created,
+)
 from inv.storage.orm import Item as ItemORM
 from inv.storage.repositories import ItemRepository, LocationRepository, MovementRepository
+
+Direction = Literal["IN", "OUT", "ADJUST"]
 
 
 class ScanResult(NamedTuple):
@@ -21,14 +31,12 @@ class ScanResult(NamedTuple):
     location_id: int
     item: ItemORM
     on_hand: int
-    direction: str
+    direction: Direction
     delta: int
 
 
 class ScanError(Exception):
     """Base exception for scan errors."""
-
-    pass
 
 
 class NegativeStockError(ScanError):
@@ -53,10 +61,28 @@ class LocationNotFoundError(ScanError):
         super().__init__(f"Location {location_id} not found")
 
 
+def _compute_delta(direction: Direction, qty_multiplier: int) -> int:
+    """Turn a (direction, qty_multiplier) pair into a signed delta.
+
+    - IN contributes +qty_multiplier eaches.
+    - OUT contributes -qty_multiplier eaches.
+    - ADJUST contributes the raw qty_multiplier (may be negative if the
+      operator is reconciling a shrink; M2 validates qty_multiplier >= 1
+      at the API layer so this currently always yields +qty for ADJUST,
+      but the service does not enforce sign so reconciliation tooling
+      can land in M3+ without another service-layer change).
+    """
+    if direction == "IN":
+        return qty_multiplier
+    if direction == "OUT":
+        return -qty_multiplier
+    return qty_multiplier
+
+
 def record_scan(
     session: Session,
     gtin: str,
-    direction: str,
+    direction: Direction,
     qty_multiplier: int = 1,
     location_id: int = 1,
     actor: str | None = None,
@@ -64,11 +90,18 @@ def record_scan(
 ) -> ScanResult:
     """Record a barcode scan and update inventory.
 
+    All writes happen inside a single transaction. Emits
+    ``item.created`` (only on first sighting) and ``movement.created``
+    (every scan) via :mod:`inv.core.events` after commit.
+
     Args:
         session: Database session.
-        gtin: The barcode (GTIN) scanned.
-        direction: 'IN', 'OUT', or 'ADJUST'.
-        qty_multiplier: Number of eaches per scan (1 for each, 12 for case, etc).
+        gtin: The barcode (GTIN) scanned. Caller is responsible for
+            format validation at the API layer.
+        direction: ``"IN"``, ``"OUT"``, or ``"ADJUST"`` — enforced by
+            :data:`Direction`.
+        qty_multiplier: Number of eaches per scan (1 for each, 12 for a
+            case of 12, etc.). API layer validates >= 1.
         location_id: Which location to move stock from/to.
         actor: Who performed the scan (optional).
         note: Additional notes about the movement (optional).
@@ -78,33 +111,29 @@ def record_scan(
 
     Raises:
         LocationNotFoundError: If location_id doesn't exist.
-        NegativeStockError: If direction is OUT and would drop on-hand below 0.
+        NegativeStockError: If direction is OUT and would drop on-hand
+            below 0.
     """
-    # Validate location exists
     loc_repo = LocationRepository(session)
-    location = loc_repo.get_by_id(location_id)
-    if not location:
+    item_repo = ItemRepository(session)
+    mov_repo = MovementRepository(session)
+
+    # Validate location exists
+    if loc_repo.get_by_id(location_id) is None:
         raise LocationNotFoundError(location_id)
 
-    # Get or create item (stub if unknown)
-    item_repo = ItemRepository(session)
-    item = item_repo.upsert(gtin, needs_review=(True if not item_repo.get_by_gtin(gtin) else False))
+    # Get or create item stub — idempotent, does NOT clobber
+    # ``needs_review`` on re-scan (issue #10).
+    item, item_was_created = item_repo.get_or_create_stub(gtin)
 
-    # Calculate delta
-    mov_repo = MovementRepository(session)
-    delta = (
-        qty_multiplier
-        if direction == "IN"
-        else -qty_multiplier
-        if direction == "OUT"
-        else qty_multiplier
-    )
+    # Compute signed delta
+    delta = _compute_delta(direction, qty_multiplier)
 
     # Guard: prevent negative stock on OUT
     if direction == "OUT":
-        on_hand = mov_repo.get_on_hand(item.id, location_id)
-        if on_hand + delta < 0:
-            raise NegativeStockError(gtin, on_hand, abs(delta))
+        current = mov_repo.get_on_hand(item.id, location_id)
+        if current + delta < 0:
+            raise NegativeStockError(gtin, current, abs(delta))
 
     # Record the movement
     movement = mov_repo.create(
@@ -116,8 +145,31 @@ def record_scan(
         note=note,
     )
 
-    # Fetch new on-hand
+    # Single commit covers item stub (if created) + movement.
+    session.commit()
+
+    # Re-read on_hand from the view after commit.
     on_hand_after = mov_repo.get_on_hand(item.id, location_id)
+
+    # Emit events AFTER commit so subscribers see a consistent DB state.
+    if item_was_created:
+        item_created.send(
+            "record_scan",
+            event=ItemCreatedEvent(item_id=item.id, gtin=item.gtin, source="stub"),
+        )
+
+    movement_created.send(
+        "record_scan",
+        event=MovementCreatedEvent(
+            movement_id=movement.id,
+            item_id=item.id,
+            location_id=location_id,
+            delta=delta,
+            direction=direction,
+            actor=actor,
+            created_at=movement.created_at,
+        ),
+    )
 
     return ScanResult(
         movement_id=movement.id,

--- a/inv/main.py
+++ b/inv/main.py
@@ -7,16 +7,28 @@ from fastapi.responses import HTMLResponse
 from inv import __version__
 from inv.api.routes_scan import router as scan_router
 from inv.settings import Settings
+from inv.storage.db import init_engine
 from inv.web import mount_static, templates
 
 
 def create_app(settings: Settings) -> FastAPI:
-    """Create and configure the FastAPI application."""
+    """Create and configure the FastAPI application.
+
+    The settings and a single SQLAlchemy engine are stored on
+    ``app.state`` so every request (and every test) shares the same
+    connection pool and the same configuration. Tests that want a
+    different DB construct a new app with fresh settings; nothing is
+    read from the environment at request time.
+    """
     app = FastAPI(
         title="open-inventory",
         version=__version__,
         description="Lightweight barcode scan-in/scan-out inventory system",
     )
+
+    # Bind settings + engine on app state (DI reads from here).
+    app.state.settings = settings
+    app.state.engine = init_engine(settings)
 
     # CORS: V1 binds 127.0.0.1 only by default; loosen only on LAN deploys.
     # NOTE: allow_credentials=True with allow_origins=["*"] is rejected by

--- a/inv/storage/db.py
+++ b/inv/storage/db.py
@@ -1,5 +1,7 @@
 """Database engine and session management."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from sqlalchemy import Engine, create_engine, event
@@ -9,27 +11,35 @@ from inv.settings import Settings
 
 
 def init_engine(settings: Settings) -> Engine:
-    """Initialize SQLAlchemy engine with WAL mode for SQLite."""
+    """Initialize a SQLAlchemy engine with SQLite WAL + sensible pragmas.
+
+    Listeners are attached to the returned engine **instance** — not to
+    the ``Engine`` class — so repeated ``init_engine`` calls (tests,
+    multiple app factories) do not accumulate duplicate PRAGMA
+    executions on every ``connect``.
+    """
     db_path = settings.db_path
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Construct SQLite URL
-    url = f"sqlite:///{db_path}"
-    engine = create_engine(url, echo=False, connect_args={"check_same_thread": False})
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
 
-    # Enable WAL mode for concurrent read access
-    @event.listens_for(Engine, "connect")
-    def set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
-        """Set SQLite pragmas for WAL mode and other optimizations."""
-        if hasattr(dbapi_connection, "execute"):
-            cursor = dbapi_connection.cursor()
-            cursor.execute("PRAGMA journal_mode=WAL")
-            cursor.execute("PRAGMA synchronous=NORMAL")
-            cursor.close()
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection: Any, _connection_record: Any) -> None:
+        """WAL mode + NORMAL sync for the SQLite workload described in §8."""
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
     return engine
 
 
 def get_session_factory(engine: Engine) -> sessionmaker[Session]:
-    """Create a session factory."""
+    """Create a session factory bound to the given engine."""
     return sessionmaker(engine, class_=Session, expire_on_commit=False)

--- a/inv/storage/repositories.py
+++ b/inv/storage/repositories.py
@@ -1,10 +1,14 @@
 """Repository pattern for data access.
 
-Repositories abstract the ORM layer and provide a clean interface for services.
+Repositories wrap the ORM and expose intent-revealing methods to the
+service layer. No business logic lives here — just CRUD and read models.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from inv.storage.orm import Item, Location, Movement
@@ -25,23 +29,38 @@ class ItemRepository:
         """Get an item by ID."""
         return self.session.query(Item).filter_by(id=item_id).first()
 
-    def create(self, gtin: str, **kwargs) -> Item:  # type: ignore[no-untyped-def]
-        """Create a new item."""
-        item = Item(gtin=gtin, **kwargs)
+    def create(self, gtin: str, **fields: Any) -> Item:
+        """Create a new item. Caller is responsible for flushing/committing."""
+        item = Item(gtin=gtin, **fields)
         self.session.add(item)
-        self.session.commit()
+        self.session.flush()
         return item
 
-    def upsert(self, gtin: str, **kwargs) -> Item:  # type: ignore[no-untyped-def]
-        """Get or create an item. If it exists, update it."""
-        item = self.get_by_gtin(gtin)
-        if item:
-            for key, value in kwargs.items():
-                if value is not None:
-                    setattr(item, key, value)
-            self.session.commit()
-            return item
-        return self.create(gtin, **kwargs)
+    def get_or_create_stub(self, gtin: str) -> tuple[Item, bool]:
+        """Return (item, created) — idempotent by GTIN.
+
+        If the item already exists, return it unchanged (never touches
+        ``needs_review`` or any other field). If it doesn't exist,
+        create a ``needs_review=True`` stub.
+
+        This explicit shape replaces the old ``upsert(**kwargs)`` which
+        clobbered ``needs_review`` on every re-scan (see issue #10).
+        """
+        existing = self.get_by_gtin(gtin)
+        if existing is not None:
+            return existing, False
+        return self.create(gtin, needs_review=True, source="stub"), True
+
+    def update_fields(self, item: Item, **fields: Any) -> Item:
+        """Update one or more fields on an existing item.
+
+        Only writes fields that were explicitly passed. Used by M3's
+        enrichment flow; M2 does not call this from the scan path.
+        """
+        for key, value in fields.items():
+            setattr(item, key, value)
+        self.session.flush()
+        return item
 
 
 class LocationRepository:
@@ -77,24 +96,28 @@ class MovementRepository:
         location_id: int,
         delta: int,
         direction: str,
-        **kwargs: object,
+        actor: str | None = None,
+        note: str | None = None,
     ) -> Movement:
-        """Create a new movement record."""
+        """Create a new movement row. Caller owns the commit."""
         movement = Movement(
             item_id=item_id,
             location_id=location_id,
             delta=delta,
             direction=direction,
-            **kwargs,
+            actor=actor,
+            note=note,
         )
         self.session.add(movement)
-        self.session.commit()
+        self.session.flush()
         return movement
 
     def get_on_hand(self, item_id: int, location_id: int) -> int:
-        """Get the current on-hand quantity for an item at a location."""
-        from sqlalchemy import text
+        """Get the current on-hand quantity for an item at a location.
 
+        Reads from the ``inventory_view`` SQL VIEW created by the baseline
+        migration. Returns 0 if no movements exist.
+        """
         result = self.session.execute(
             text(
                 "SELECT COALESCE(on_hand, 0) FROM inventory_view "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,8 +74,14 @@ def session(engine: Engine) -> Iterator[Session]:
 
 
 @pytest.fixture
-def app(settings: Settings):  # type: ignore[no-untyped-def]
-    """Create FastAPI test app."""
+def app(settings: Settings, engine: Engine):  # type: ignore[no-untyped-def]
+    """Create a FastAPI test app bound to a migrated temp DB.
+
+    Depends on ``engine`` so the schema is guaranteed to exist and the
+    default ``Main`` location is seeded. The app instance itself will
+    call ``init_engine(settings)`` again — both engines point at the
+    same SQLite file (the one in ``temp_db``), so there's no bleed.
+    """
     return create_app(settings)
 
 

--- a/tests/integration/test_scan_flow.py
+++ b/tests/integration/test_scan_flow.py
@@ -1,0 +1,172 @@
+"""HTTP-level tests for the scan loop (M2).
+
+Covers the ``GET /scan`` page render and the ``POST /scan`` request
+contract — including every branch of the M2 exit criteria and every
+validation rule on :class:`inv.api.routes_scan.ScanRequest`.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------- #
+# GET /scan                                                              #
+# ---------------------------------------------------------------------- #
+
+
+def test_get_scan_page_renders_mode_selector(client: TestClient) -> None:
+    """GET /scan returns the scan UI with every required control."""
+    response = client.get("/scan")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+
+    body = response.text
+    # Mode selector values (Each, Case, Cluster, Custom)
+    assert 'value="1"' in body
+    assert 'value="12"' in body
+    assert 'value="6"' in body
+    assert 'value="custom"' in body
+    # Direction controls
+    assert 'value="IN"' in body
+    assert 'value="OUT"' in body
+    assert 'value="ADJUST"' in body
+    # Autofocus
+    assert "autofocus" in body
+    # Vendored assets referenced
+    assert "/static/js/htmx.min.js" in body
+    assert "/static/js/alpine.min.js" in body
+
+
+# ---------------------------------------------------------------------- #
+# POST /scan — happy paths                                               #
+# ---------------------------------------------------------------------- #
+
+
+def test_post_scan_in_creates_stub_and_increments(client: TestClient) -> None:
+    """POST /scan with direction=IN returns 200 HTML with the new on-hand."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "1234567890123", "direction": "IN", "qty_multiplier": 3, "location_id": 1},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    # on-hand shows 3
+    assert ">3<" in body
+    # GTIN appears somewhere (either as title or detail)
+    assert "1234567890123" in body
+
+
+def test_post_scan_out_decrements_on_hand(client: TestClient) -> None:
+    """IN then OUT at the same GTIN reduces on-hand."""
+    gtin = "1111111111111"
+    client.post(
+        "/scan",
+        json={"gtin": gtin, "direction": "IN", "qty_multiplier": 10, "location_id": 1},
+    )
+    response = client.post(
+        "/scan",
+        json={"gtin": gtin, "direction": "OUT", "qty_multiplier": 4, "location_id": 1},
+    )
+    assert response.status_code == 200
+    # 10 - 4 = 6 on hand
+    assert ">6<" in response.text
+
+
+# ---------------------------------------------------------------------- #
+# POST /scan — error paths (M2 exit criteria: "clear error" on over-out) #
+# ---------------------------------------------------------------------- #
+
+
+def test_post_scan_over_scan_out_returns_409_with_clear_error(client: TestClient) -> None:
+    """Over-scan-out returns 409 Conflict with a human-readable message."""
+    gtin = "2222222222222"
+    client.post(
+        "/scan",
+        json={"gtin": gtin, "direction": "IN", "qty_multiplier": 2, "location_id": 1},
+    )
+    response = client.post(
+        "/scan",
+        json={"gtin": gtin, "direction": "OUT", "qty_multiplier": 99, "location_id": 1},
+    )
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert "Cannot remove" in detail
+    assert "99" in detail
+    assert "only 2 on hand" in detail
+
+
+def test_post_scan_unknown_location_returns_404(client: TestClient) -> None:
+    """Non-existent location returns 404 with a clear error."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "3333333333333", "direction": "IN", "qty_multiplier": 1, "location_id": 999},
+    )
+    assert response.status_code == 404
+    assert "Location 999" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------- #
+# POST /scan — validation (422 instead of 500)                            #
+# ---------------------------------------------------------------------- #
+
+
+def test_post_scan_invalid_direction_returns_422(client: TestClient) -> None:
+    """Invalid direction values are rejected at the edge, not at the DB."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "4444444444444", "direction": "BOGUS", "qty_multiplier": 1, "location_id": 1},
+    )
+    # Must be 422, never 500 (regression for issue #9)
+    assert response.status_code == 422
+
+
+def test_post_scan_lowercase_direction_returns_422(client: TestClient) -> None:
+    """Direction enum is case-sensitive; \"in\" is not \"IN\"."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "4444444444444", "direction": "in", "qty_multiplier": 1, "location_id": 1},
+    )
+    assert response.status_code == 422
+
+
+def test_post_scan_empty_gtin_returns_422(client: TestClient) -> None:
+    """Empty GTIN is rejected by the min_length constraint."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "", "direction": "IN", "qty_multiplier": 1, "location_id": 1},
+    )
+    assert response.status_code == 422
+
+
+def test_post_scan_short_gtin_returns_422(client: TestClient) -> None:
+    """GTIN shorter than 6 characters is rejected."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "12345", "direction": "IN", "qty_multiplier": 1, "location_id": 1},
+    )
+    assert response.status_code == 422
+
+
+def test_post_scan_zero_qty_multiplier_returns_422(client: TestClient) -> None:
+    """qty_multiplier=0 is a no-op and rejected as nonsensical."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "5555555555555", "direction": "IN", "qty_multiplier": 0, "location_id": 1},
+    )
+    assert response.status_code == 422
+
+
+def test_post_scan_negative_qty_multiplier_returns_422(client: TestClient) -> None:
+    """Negative qty_multiplier with direction=IN is semantically incoherent."""
+    response = client.post(
+        "/scan",
+        json={"gtin": "5555555555555", "direction": "IN", "qty_multiplier": -3, "location_id": 1},
+    )
+    assert response.status_code == 422
+
+
+def test_post_scan_missing_body_returns_422(client: TestClient) -> None:
+    """Empty body fails Pydantic validation (missing gtin)."""
+    response = client.post("/scan", json={})
+    assert response.status_code == 422

--- a/tests/unit/test_scan_services.py
+++ b/tests/unit/test_scan_services.py
@@ -92,3 +92,78 @@ def test_record_scan_adjust_direction(session) -> None:
     result = record_scan(session, gtin=gtin, direction="ADJUST", qty_multiplier=5, location_id=1)
     assert result.on_hand == 15
     assert result.direction == "ADJUST"
+
+
+def test_record_scan_does_not_clobber_needs_review_on_rescan(session) -> None:
+    """Re-scanning a known GTIN must NOT reset the ``needs_review`` flag.
+
+    Regression for issue #10: the old ``upsert(**kwargs)`` path passed
+    ``needs_review=False`` on every re-scan and blindly overwrote the
+    column, breaking M3's manual-enrichment queue.
+    """
+    gtin = "7777777777777"
+
+    # First scan — creates a stub with needs_review=True
+    r1 = record_scan(session, gtin=gtin, direction="IN", qty_multiplier=1, location_id=1)
+    assert r1.item.needs_review is True
+
+    # Second scan — the flag must remain True (no human has enriched yet)
+    r2 = record_scan(session, gtin=gtin, direction="IN", qty_multiplier=1, location_id=1)
+    assert r2.item.needs_review is True
+
+    # Simulate an operator enriching the item (clearing the flag)
+    r2.item.needs_review = False
+    session.commit()
+
+    # Third scan — the flag stays cleared (record_scan must not re-set it)
+    r3 = record_scan(session, gtin=gtin, direction="IN", qty_multiplier=1, location_id=1)
+    assert r3.item.needs_review is False
+
+
+def test_record_scan_emits_movement_created_signal(session) -> None:
+    """Every ``record_scan`` fires ``movement.created`` with the correct payload."""
+    from inv.core.events import MovementCreatedEvent, movement_created
+
+    received: list[MovementCreatedEvent] = []
+
+    def _catch(_sender: object, event: MovementCreatedEvent) -> None:
+        received.append(event)
+
+    movement_created.connect(_catch)
+    try:
+        result = record_scan(
+            session, gtin="8888888888888", direction="IN", qty_multiplier=3, location_id=1
+        )
+    finally:
+        movement_created.disconnect(_catch)
+
+    assert len(received) == 1
+    evt = received[0]
+    assert evt.movement_id == result.movement_id
+    assert evt.item_id == result.item_id
+    assert evt.location_id == 1
+    assert evt.delta == 3
+    assert evt.direction == "IN"
+
+
+def test_record_scan_emits_item_created_only_once(session) -> None:
+    """``item.created`` fires on the first scan only; re-scans are silent."""
+    from inv.core.events import ItemCreatedEvent, item_created
+
+    received: list[ItemCreatedEvent] = []
+
+    def _catch(_sender: object, event: ItemCreatedEvent) -> None:
+        received.append(event)
+
+    gtin = "9000000000009"
+    item_created.connect(_catch)
+    try:
+        record_scan(session, gtin=gtin, direction="IN", qty_multiplier=1, location_id=1)
+        record_scan(session, gtin=gtin, direction="IN", qty_multiplier=1, location_id=1)
+        record_scan(session, gtin=gtin, direction="IN", qty_multiplier=1, location_id=1)
+    finally:
+        item_created.disconnect(_catch)
+
+    assert len(received) == 1
+    assert received[0].gtin == gtin
+    assert received[0].source == "stub"


### PR DESCRIPTION
## Summary

Closes the M2 audit blockers so the milestone is genuinely complete before M3 starts.

- **#8** `movement.created` + `item.created` signals now defined in `inv/core/events.py` with frozen payload dataclasses matching §6; `record_scan()` emits them after commit.
- **#9** `ScanRequest.direction` is now `Literal["IN","OUT","ADJUST"]`. Invalid directions (including lowercase `"in"`) return 422 instead of 500.
- **#10** `ItemRepository.upsert` replaced with `get_or_create_stub()` + `update_fields()`. `record_scan` only touches `needs_review` at creation time, so the flag survives re-scans and M3's manual-enrichment queue will actually work.
- **#11** New `tests/integration/test_scan_flow.py` with 12 HTTP-level tests covering every branch of the M2 exit criteria + the validation rules. Plus 3 new service-layer tests for `needs_review` stickiness and event emission.
- **#12** `qty_multiplier >= 1`, `gtin` length 6–14, `location_id >= 1`, `actor`/`note` capped. All invalid inputs return 422.

## Bonus fixes picked up along the way

- **App-scoped engine + settings** — HTTP tests revealed that `get_session` was re-resolving `Settings()` on every request (reading from the env), so tests were silently hitting the user's real XDG DB. `create_app` now binds `settings` and a single `Engine` to `app.state`; dependencies read from there. One engine per app, not per request.
- **M1 §2.1 fix (free)** — `init_engine` now attaches the PRAGMA listener to the engine instance, not the `Engine` class, so repeated calls no longer register duplicate listeners.
- **`PRAGMA foreign_keys=ON`** added so FK constraints actually enforce.
- Deleted the unused `ScanResponse` / `ScanResponseItem` Pydantic models and the docstring that falsely claimed JSON response support.
- Replaced the private `starlette._TemplateResponse` import with `HTMLResponse` as the return annotation.
- Single `session.commit()` per `record_scan` instead of three — atomic rollback on failure.

## Verification

```
pytest                   # 33 passed (was 18); +15 new tests
ruff check inv tests     # clean
mypy inv                 # clean (34 files)
inventory init           # idempotent against a fresh temp DB
```

New test breakdown:
- `tests/integration/test_scan_flow.py` — 12 tests
- `tests/unit/test_scan_services.py` — +3 tests (needs_review stickiness, `movement.created` emission, `item.created` once-only)

## Commit layout

One commit per logical change, with the in-flight fix for the test-isolation bug called out separately so reviewers can see why it was necessary:

1. `feat(M2,#8)` define blinker signals + payloads
2. `fix(M2,#8,#10)` emit signals + stop clobbering needs_review
3. `fix(M2,#9,#12)` Pydantic validation (Literal direction, bounds)
4. `fix(M2)` app-scoped engine + proper test isolation
5. `test(M2,#11)` HTTP-level + event + needs_review coverage

## Not in this PR

Leftover M2 opportunities from the audit (§3 items 3.2–3.9) and the M1 hardening tail (ARM CI, `datetime.utcnow`, `types-httpx`, inline-script partial cleanup, scan-history persistence, Pydantic domain adoption) are intentionally deferred to a follow-up so this PR stays focused on closing the five filed blockers.

Closes #8, closes #9, closes #10, closes #11, closes #12