### PR TITLE
feat(M4): casepacks, inventory view, CSV export

### DIFF
--- a/inv/api/routes_export.py
+++ b/inv/api/routes_export.py
@@ -1,0 +1,122 @@
+"""CSV export routes.
+
+Covers:
+  GET /export/items.csv     — all items with current on-hand totals
+  GET /export/movements.csv — full movement log (append-only event log)
+
+Both endpoints stream a plain CSV response with appropriate headers so
+browsers trigger a file download. No pagination — V1 is designed for
+small-scale deployments where the full dataset fits in memory.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from inv.api.deps import get_session
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+def _csv_response(filename: str, headers: list[str], rows: list[tuple]) -> StreamingResponse:
+    """Build a StreamingResponse containing a UTF-8 CSV with BOM.
+
+    The BOM (``\ufeff``) ensures Excel opens the file correctly without
+    a manual encoding step — important for mutual aid groups who will
+    likely use spreadsheet software to review exports.
+    """
+    buf = io.StringIO()
+    buf.write("\ufeff")  # UTF-8 BOM for Excel compatibility
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+    writer.writerows(rows)
+    buf.seek(0)
+
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv; charset=utf-8-sig",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/items.csv")
+async def export_items(
+    session: Annotated[Session, Depends(get_session)],
+) -> StreamingResponse:
+    """Export all items with their total on-hand (summed across all locations).
+
+    Columns: id, gtin, name, brand, category, uom, pack_size, source,
+             needs_review, on_hand_total, created_at, updated_at
+    """
+    results = session.execute(
+        text("""
+            SELECT
+                i.id,
+                i.gtin,
+                i.name,
+                i.brand,
+                i.category,
+                i.uom,
+                i.pack_size,
+                i.source,
+                i.needs_review,
+                COALESCE(SUM(v.on_hand), 0) AS on_hand_total,
+                i.created_at,
+                i.updated_at
+            FROM item i
+            LEFT JOIN inventory_view v ON v.item_id = i.id
+            GROUP BY i.id
+            ORDER BY i.id
+        """)
+    ).fetchall()
+
+    headers = [
+        "id", "gtin", "name", "brand", "category", "uom", "pack_size",
+        "source", "needs_review", "on_hand_total", "created_at", "updated_at",
+    ]
+    return _csv_response("items.csv", headers, [tuple(r) for r in results])
+
+
+@router.get("/movements.csv")
+async def export_movements(
+    session: Annotated[Session, Depends(get_session)],
+) -> StreamingResponse:
+    """Export the full movement log.
+
+    Columns: id, item_id, item_gtin, item_name, location_id, location_name,
+             delta, direction, actor, note, created_at
+    """
+    results = session.execute(
+        text("""
+            SELECT
+                m.id,
+                m.item_id,
+                i.gtin      AS item_gtin,
+                i.name      AS item_name,
+                m.location_id,
+                l.name      AS location_name,
+                m.delta,
+                m.direction,
+                m.actor,
+                m.note,
+                m.created_at
+            FROM movement m
+            JOIN item     i ON i.id = m.item_id
+            JOIN location l ON l.id = m.location_id
+            ORDER BY m.id
+        """)
+    ).fetchall()
+
+    headers = [
+        "id", "item_id", "item_gtin", "item_name",
+        "location_id", "location_name",
+        "delta", "direction", "actor", "note", "created_at",
+    ]
+    return _csv_response("movements.csv", headers, [tuple(r) for r in results])

--- a/inv/api/routes_inventory.py
+++ b/inv/api/routes_inventory.py
@@ -1,0 +1,63 @@
+"""Inventory view routes.
+
+Covers:
+  GET /inventory — per-item on-hand quantities across all locations,
+                   with last-movement timestamp and optional filters.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from inv.api.deps import get_session
+from inv.web import templates
+
+router = APIRouter(prefix="/inventory", tags=["inventory"])
+
+
+@router.get("", response_class=HTMLResponse)
+async def get_inventory(
+    request: Request,
+    session: Annotated[Session, Depends(get_session)],
+) -> HTMLResponse:
+    """Render the inventory on-hand view.
+
+    Queries the ``inventory_view`` SQL VIEW (created by the baseline
+    migration) and joins item + location names. Returns rows only where
+    ``on_hand != 0`` by default so zero-stock items don't clutter the
+    view. The last movement timestamp is fetched per item/location pair.
+    """
+    rows = session.execute(
+        text("""
+            SELECT
+                i.id        AS item_id,
+                i.gtin      AS gtin,
+                i.name      AS name,
+                i.brand     AS brand,
+                i.needs_review AS needs_review,
+                l.id        AS location_id,
+                l.name      AS location_name,
+                v.on_hand   AS on_hand,
+                (
+                    SELECT MAX(m.created_at)
+                    FROM movement m
+                    WHERE m.item_id = v.item_id
+                      AND m.location_id = v.location_id
+                ) AS last_movement_at
+            FROM inventory_view v
+            JOIN item     i ON i.id = v.item_id
+            JOIN location l ON l.id = v.location_id
+            ORDER BY l.name, i.name NULLS LAST, i.gtin
+        """)
+    ).mappings().all()
+
+    return templates.TemplateResponse(
+        request,
+        "inventory.html",
+        {"rows": rows},
+    )

--- a/inv/api/routes_items.py
+++ b/inv/api/routes_items.py
@@ -1,9 +1,11 @@
-"""Items routes — list, detail, and manual enrichment form.
+"""Items routes — list, detail, enrichment form, and pack alias CRUD.
 
 Covers:
-  GET  /items                — paginated item list, optional ?filter=needs_review
-  GET  /items/{id}/enrich   — render the enrichment form
-  POST /items/{id}/enrich   — submit enrichment; clears needs_review flag
+  GET  /items                          — item list, optional ?filter=needs_review
+  GET  /items/{id}/enrich              — render enrichment form (with alias list)
+  POST /items/{id}/enrich              — submit enrichment; clears needs_review
+  POST /items/{id}/aliases             — add a pack alias
+  POST /items/{id}/aliases/{gtin}/delete — remove a pack alias
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ from sqlalchemy.orm import Session
 from inv.api.deps import get_session
 from inv.core.services import enrich_item
 from inv.storage.orm import Item
-from inv.storage.repositories import ItemRepository
+from inv.storage.repositories import AliasRepository, ItemRepository
 from inv.web import templates
 
 router = APIRouter(prefix="/items", tags=["items"])
@@ -54,14 +56,15 @@ async def get_enrich_form(
     repo = ItemRepository(session)
     item = repo.get_by_id(item_id)
     if item is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Item {item_id} not found",
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Item {item_id} not found")
+
+    alias_repo = AliasRepository(session)
+    aliases = alias_repo.list_for_item(item_id)
+
     return templates.TemplateResponse(
         request,
         "enrich_form.html",
-        {"item": item, "message": None},
+        {"item": item, "aliases": aliases, "message": None},
     )
 
 
@@ -77,16 +80,11 @@ async def post_enrich_form(
 ) -> RedirectResponse:
     """Submit enrichment data for an item and clear its needs_review flag.
 
-    Redirects to the items list on success so a re-POST on refresh is
-    avoided (Post/Redirect/Get pattern).
+    Redirects to /items on success (Post/Redirect/Get).
     """
     repo = ItemRepository(session)
-    item = repo.get_by_id(item_id)
-    if item is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Item {item_id} not found",
-        )
+    if repo.get_by_id(item_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Item {item_id} not found")
 
     try:
         enrich_item(
@@ -98,9 +96,75 @@ async def post_enrich_form(
             note=note.strip() or None,
         )
     except KeyError as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e),
-        ) from e
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
     return RedirectResponse(url="/items", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/{item_id}/aliases")
+async def add_alias(
+    item_id: int,
+    session: Annotated[Session, Depends(get_session)],
+    alias_gtin: Annotated[str, Form(min_length=6, max_length=14)],
+    multiplier: Annotated[int, Form(ge=2, le=10000)],
+    label: Annotated[str, Form(max_length=100)] = "",
+) -> RedirectResponse:
+    """Register a new pack alias for an item.
+
+    The alias GTIN must not already exist (either as an item GTIN or
+    another alias). Redirects back to the enrichment form on success.
+    """
+    repo = ItemRepository(session)
+    if repo.get_by_id(item_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Item {item_id} not found")
+
+    alias_repo = AliasRepository(session)
+
+    # Guard: alias GTIN must not conflict with an existing item GTIN
+    if repo.get_by_gtin(alias_gtin) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"GTIN {alias_gtin} already exists as a canonical item",
+        )
+    # Guard: alias GTIN must not already be registered
+    if alias_repo.get_by_gtin(alias_gtin) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Alias GTIN {alias_gtin} is already registered",
+        )
+
+    alias_repo.create(
+        gtin=alias_gtin,
+        item_id=item_id,
+        multiplier=multiplier,
+        label=label.strip() or None,
+    )
+    session.commit()
+
+    return RedirectResponse(
+        url=f"/items/{item_id}/enrich", status_code=status.HTTP_303_SEE_OTHER
+    )
+
+
+@router.post("/{item_id}/aliases/{alias_gtin}/delete")
+async def delete_alias(
+    item_id: int,
+    alias_gtin: str,
+    session: Annotated[Session, Depends(get_session)],
+) -> RedirectResponse:
+    """Delete a pack alias. Redirects back to the enrichment form."""
+    repo = ItemRepository(session)
+    if repo.get_by_id(item_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Item {item_id} not found")
+
+    alias_repo = AliasRepository(session)
+    if not alias_repo.delete(alias_gtin):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Alias {alias_gtin} not found",
+        )
+    session.commit()
+
+    return RedirectResponse(
+        url=f"/items/{item_id}/enrich", status_code=status.HTTP_303_SEE_OTHER
+    )

--- a/inv/api/routes_scan.py
+++ b/inv/api/routes_scan.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from inv.api.deps import get_session
+from inv.core.packs import resolve_alias
 from inv.core.services import (
     LocationNotFoundError,
     NegativeStockError,
@@ -58,10 +59,14 @@ async def post_scan(
 ) -> HTMLResponse:
     """Record a barcode scan and update inventory.
 
-    On first sight of a GTIN the lookup chain runs (cache → OFF →
-    Open Library → OpenGTINdb → UPCitemdb). A hit enriches the item
-    stub in the same transaction; a miss leaves it flagged
-    ``needs_review=True``.
+    Processing order:
+    1. Resolve pack alias — if the scanned GTIN is a registered case/inner
+       barcode, rewrite to the canonical item GTIN and apply the alias
+       multiplier (overriding the operator's qty_multiplier).
+    2. Run the provider chain (cache → OFF → Open Library → OpenGTINdb →
+       UPCitemdb) only for first-seen canonical GTINs.
+    3. Call record_scan with the resolved GTIN, effective multiplier, and
+       any lookup result.
 
     Returns an HTML partial for HTMX/fetch clients. Errors use standard
     HTTP status codes with JSON ``{"detail": "..."}`` bodies:
@@ -71,26 +76,31 @@ async def post_scan(
     - 422: Validation error (bad direction, empty GTIN, non-positive
            qty_multiplier, etc.) — emitted by Pydantic automatically.
     """
-    # Run the provider chain only for first-seen GTINs. We peek at the
-    # DB first; if the item already exists we skip the network round-trip
-    # entirely (the chain would just hit the cache anyway, but this is
-    # cheaper and keeps the fast path fast).
+    # Step 1: pack alias resolution — rewrites GTIN + multiplier if matched.
+    resolution = resolve_alias(session, req.gtin)
+    effective_gtin = resolution.canonical_gtin
+    effective_multiplier = (
+        resolution.multiplier if resolution.was_alias else req.qty_multiplier
+    )
+
+    # Step 2: provider chain — only for first-seen canonical GTINs.
     from inv.storage.repositories import ItemRepository
 
     item_repo = ItemRepository(session)
-    is_new_gtin = item_repo.get_by_gtin(req.gtin) is None
+    is_new_gtin = item_repo.get_by_gtin(effective_gtin) is None
 
     lookup_result = None
     if is_new_gtin:
         chain = ChainRunner(session)
-        lookup_result = await chain.run(req.gtin)
+        lookup_result = await chain.run(effective_gtin)
 
+    # Step 3: record the movement.
     try:
         result = record_scan(
             session,
-            gtin=req.gtin,
+            gtin=effective_gtin,
             direction=req.direction,
-            qty_multiplier=req.qty_multiplier,
+            qty_multiplier=effective_multiplier,
             location_id=req.location_id,
             actor=req.actor,
             note=req.note,
@@ -107,10 +117,14 @@ async def post_scan(
             detail=str(e),
         ) from e
 
-    # Construct human-readable message
+    # Build human-readable message; note alias auto-multiply if applicable.
     verb = {"IN": "Scanned in", "OUT": "Scanned out", "ADJUST": "Adjusted"}[req.direction]
     item_label = result.item.name or result.item.gtin
-    message = f"{verb} {req.qty_multiplier} × {item_label}"
+    if resolution.was_alias:
+        alias_tag = f" via {resolution.alias_label or 'alias'} ×{resolution.multiplier}"
+    else:
+        alias_tag = ""
+    message = f"{verb} {effective_multiplier} × {item_label}{alias_tag}"
 
     context = {
         "item": result.item,
@@ -118,5 +132,6 @@ async def post_scan(
         "direction": req.direction,
         "delta": result.delta,
         "message": message,
+        "was_alias": resolution.was_alias,
     }
     return templates.TemplateResponse(request, "partials/scan_result.html", context)

--- a/inv/core/packs.py
+++ b/inv/core/packs.py
@@ -1,0 +1,69 @@
+"""Pack alias resolution and multiplier math.
+
+DEVELOPMENT_PLAN.md §3 describes the casepack model:
+- ``item.pack_size`` stores the default eaches-per-pack.
+- ``pack_alias`` maps alternate GTINs (inner, carton, case) → canonical
+  item + multiplier.
+- Scanning a case barcode that matches a ``pack_alias`` auto-multiplies
+  without operator input.
+- All storage math is in eaches; packs are purely scan-time multipliers.
+
+This module exposes one public function used by the scan route:
+``resolve_alias`` — look up a scanned GTIN and return the canonical item
+GTIN + effective multiplier if an alias exists, otherwise return the
+original GTIN + 1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from inv.storage.repositories import AliasRepository
+
+
+@dataclass
+class AliasResolution:
+    """Result of resolving a scanned GTIN through the pack_alias table.
+
+    Attributes:
+        canonical_gtin: The item GTIN that should be looked up / moved.
+            Equal to the scanned GTIN if no alias matched.
+        multiplier: Effective eaches-per-scan. 1 if no alias matched.
+        alias_label: Human-readable alias label (e.g. "case-12"), or None.
+        was_alias: True if the scanned GTIN matched a pack_alias row.
+    """
+
+    canonical_gtin: str
+    multiplier: int
+    alias_label: str | None
+    was_alias: bool
+
+
+def resolve_alias(session: Session, scanned_gtin: str) -> AliasResolution:
+    """Resolve a scanned GTIN through the pack_alias table.
+
+    Returns an :class:`AliasResolution` with the canonical GTIN and the
+    effective multiplier. If no alias is registered the scanned GTIN is
+    returned unchanged with multiplier=1.
+
+    Called by the scan route *before* the lookup chain so that a case
+    barcode resolves to the known canonical item without triggering a
+    fresh provider lookup.
+    """
+    repo = AliasRepository(session)
+    alias = repo.get_by_gtin(scanned_gtin)
+    if alias is None:
+        return AliasResolution(
+            canonical_gtin=scanned_gtin,
+            multiplier=1,
+            alias_label=None,
+            was_alias=False,
+        )
+    return AliasResolution(
+        canonical_gtin=alias.item.gtin,
+        multiplier=alias.multiplier,
+        alias_label=alias.label,
+        was_alias=True,
+    )

--- a/inv/main.py
+++ b/inv/main.py
@@ -5,6 +5,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 
 from inv import __version__
+from inv.api.routes_export import router as export_router
+from inv.api.routes_inventory import router as inventory_router
 from inv.api.routes_items import router as items_router
 from inv.api.routes_scan import router as scan_router
 from inv.settings import Settings
@@ -68,5 +70,7 @@ def create_app(settings: Settings) -> FastAPI:
     # Register routers
     app.include_router(scan_router)
     app.include_router(items_router)
+    app.include_router(inventory_router)
+    app.include_router(export_router)
 
     return app

--- a/inv/storage/repositories.py
+++ b/inv/storage/repositories.py
@@ -11,7 +11,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from inv.storage.orm import Item, Location, Movement, ProductCache
+from inv.storage.orm import Item, Location, Movement, PackAlias, ProductCache
 
 
 class ItemRepository:
@@ -126,6 +126,49 @@ class MovementRepository:
             {"item_id": item_id, "location_id": location_id},
         ).scalar()
         return int(result) if result is not None else 0
+
+
+class AliasRepository:
+    """Repository for PackAlias operations.
+
+    Pack aliases map alternate GTINs (inner pack, carton, case) to a
+    canonical item + multiplier. Used by the scan path to auto-multiply
+    without operator input, and managed via the enrichment form.
+    """
+
+    def __init__(self, session: Session) -> None:
+        """Initialize with a database session."""
+        self.session = session
+
+    def get_by_gtin(self, gtin: str) -> PackAlias | None:
+        """Return the alias for a given GTIN, or None if not registered."""
+        return self.session.query(PackAlias).filter_by(gtin=gtin).first()
+
+    def list_for_item(self, item_id: int) -> list[PackAlias]:
+        """Return all aliases registered for a canonical item."""
+        return self.session.query(PackAlias).filter_by(item_id=item_id).all()
+
+    def create(
+        self,
+        gtin: str,
+        item_id: int,
+        multiplier: int,
+        label: str | None = None,
+    ) -> PackAlias:
+        """Create a new pack alias. Caller owns the commit."""
+        alias = PackAlias(gtin=gtin, item_id=item_id, multiplier=multiplier, label=label)
+        self.session.add(alias)
+        self.session.flush()
+        return alias
+
+    def delete(self, gtin: str) -> bool:
+        """Delete an alias by GTIN. Returns True if it existed."""
+        alias = self.get_by_gtin(gtin)
+        if alias is None:
+            return False
+        self.session.delete(alias)
+        self.session.flush()
+        return True
 
 
 class CacheRepository:

--- a/inv/web/templates/enrich_form.html
+++ b/inv/web/templates/enrich_form.html
@@ -72,5 +72,63 @@
             <a href="/items" role="button" class="outline secondary">Cancel</a>
         </div>
     </form>
+
+    <hr>
+
+    <h3>Pack aliases</h3>
+    <p>
+        Register alternate GTINs (inner pack, carton, case) that should
+        auto-multiply when scanned. All quantities are stored in eaches.
+    </p>
+
+    {% if aliases %}
+    <table>
+        <thead>
+            <tr>
+                <th>Alias GTIN</th>
+                <th>Multiplier</th>
+                <th>Label</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for alias in aliases %}
+            <tr>
+                <td><code>{{ alias.gtin }}</code></td>
+                <td>×{{ alias.multiplier }}</td>
+                <td>{{ alias.label or "—" }}</td>
+                <td>
+                    <form method="POST" action="/items/{{ item.id }}/aliases/{{ alias.gtin }}/delete" style="display:inline;">
+                        <button type="submit" class="outline" style="padding: 0.2em 0.8em;">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p><em>No aliases registered.</em></p>
+    {% endif %}
+
+    <h4>Add alias</h4>
+    <form method="POST" action="/items/{{ item.id }}/aliases">
+        <div style="display: flex; gap: 1em; flex-wrap: wrap; align-items: flex-end;">
+            <label style="flex: 2; min-width: 140px;">
+                Alias GTIN
+                <input type="text" name="alias_gtin" placeholder="e.g. 03017620422003" maxlength="14" required>
+            </label>
+            <label style="flex: 1; min-width: 80px;">
+                Multiplier
+                <input type="number" name="multiplier" value="12" min="2" max="10000" required>
+            </label>
+            <label style="flex: 2; min-width: 120px;">
+                Label <small>(optional)</small>
+                <input type="text" name="label" placeholder="e.g. case-12" maxlength="100">
+            </label>
+            <div>
+                <button type="submit">Add alias</button>
+            </div>
+        </div>
+    </form>
 </section>
 {% endblock %}

--- a/inv/web/templates/inventory.html
+++ b/inv/web/templates/inventory.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}Inventory — open-inventory{% endblock %}
+
+{% block content %}
+<section>
+    <hgroup>
+        <h2>Inventory</h2>
+        <p>
+            Current on-hand by item and location.
+            <a href="/export/items.csv">Export items CSV</a> ·
+            <a href="/export/movements.csv">Export movements CSV</a>
+        </p>
+    </hgroup>
+
+    {% if rows %}
+    <div class="overflow-auto">
+        <table>
+            <thead>
+                <tr>
+                    <th>Location</th>
+                    <th>GTIN</th>
+                    <th>Name</th>
+                    <th>Brand</th>
+                    <th>On hand</th>
+                    <th>Last movement</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in rows %}
+                <tr>
+                    <td>{{ row.location_name }}</td>
+                    <td><code>{{ row.gtin }}</code></td>
+                    <td>
+                        {{ row.name or "—" }}
+                        {% if row.needs_review %}
+                        <small><mark>needs review</mark></small>
+                        {% endif %}
+                    </td>
+                    <td>{{ row.brand or "—" }}</td>
+                    <td><strong>{{ row.on_hand }}</strong></td>
+                    <td>
+                        {% if row.last_movement_at %}
+                        <small>{{ row.last_movement_at }}</small>
+                        {% else %}
+                        —
+                        {% endif %}
+                    </td>
+                    <td>
+                        <a href="/items/{{ row.item_id }}/enrich" role="button" class="outline">Enrich</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <p>No inventory yet. <a href="/scan">Scan some items</a> to get started.</p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/inv/web/templates/partials/scan_result.html
+++ b/inv/web/templates/partials/scan_result.html
@@ -2,45 +2,36 @@
 <article style="background: #f0f8ff; padding: 1.5em; border-radius: 0.5em; border-left: 4px solid #0066cc;">
     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1em;">
         <div>
-            <h4 style="margin: 0; color: #0066cc;">{{ item.name or item.gtin }}</h4>
+            <h4 style="margin: 0; color: #0066cc;"
+                data-item-name="{{ item.name or item.gtin }}">
+                {{ item.name or item.gtin }}
+            </h4>
             {% if item.brand %}
             <p style="margin: 0.5em 0 0 0; color: #666; font-size: 0.9em;">{{ item.brand }}</p>
             {% endif %}
+            {% if item.needs_review %}
+            <p style="margin: 0.3em 0 0 0; font-size: 0.85em;">
+                <mark>needs review</mark>
+                — <a href="/items/{{ item.id }}/enrich">Enrich</a>
+            </p>
+            {% endif %}
         </div>
         <div style="text-align: right;">
-            <div style="font-size: 2em; font-weight: bold; color: #0066cc;">{{ on_hand }}</div>
+            <div style="font-size: 2em; font-weight: bold; color: #0066cc;"
+                 data-on-hand="{{ on_hand }}">{{ on_hand }}</div>
             <div style="font-size: 0.9em; color: #666;">on hand</div>
         </div>
     </div>
 
     <div style="margin-top: 1em; padding-top: 1em; border-top: 1px solid #ddd; font-size: 0.9em;">
         <strong>{{ message }}</strong>
+        {% if was_alias %}
+        <span style="background:#e8f4e8;padding:0.1em 0.4em;border-radius:3px;font-size:0.85em;">auto-multiplied</span>
+        {% endif %}
         <br>
         <span style="color: #666;">GTIN: {{ item.gtin }}</span>
     </div>
 </article>
-
-<!-- Add to scan history -->
-<script>
-(function() {
-    const historyDiv = document.getElementById('scan-history');
-    if (historyDiv) {
-        const entry = document.createElement('div');
-        entry.style.padding = '0.5em';
-        entry.style.borderBottom = '1px solid #eee';
-        entry.style.fontSize = '0.85em';
-        const absDelta = Math.abs({{ delta }});
-        entry.innerHTML = '<strong>' + '{{ item.name or item.gtin }}' + '</strong><br>' +
-                          '<span style="color: #666;">' + '{{ direction }}' + ' ×' + absDelta + ', on-hand: ' + '{{ on_hand }}' + '</span>';
-        historyDiv.insertBefore(entry, historyDiv.firstChild);
-
-        // Keep only last 10 entries
-        while (historyDiv.children.length > 10) {
-            historyDiv.removeChild(historyDiv.lastChild);
-        }
-    }
-})();
-</script>
 {% else %}
 <div style="color: #cc0000; padding: 1em; background: #ffe0e0; border-radius: 0.5em;">
     <strong>Error:</strong> {{ message }}

--- a/inv/web/templates/scan.html
+++ b/inv/web/templates/scan.html
@@ -80,15 +80,48 @@
 
     <hr>
 
-    <h3>Last Scans</h3>
-    <div id="scan-history" style="border: 1px solid #ddd; padding: 1em; border-radius: 0.5em; max-height: 200px; overflow-y: auto; min-height: 100px;">
+    <h3>Last Scans <small style="font-weight:normal;font-size:0.75em;">(this session)</small></h3>
+    <div id="scan-history" style="border: 1px solid #ddd; padding: 1em; border-radius: 0.5em; max-height: 220px; overflow-y: auto; min-height: 60px;">
+        <em style="color:#999;">No scans yet.</em>
     </div>
 </section>
 
 <script>
 /**
- * Handle barcode scanner input: when user presses Enter (or scanner sends Enter),
- * POST the form data to /scan via HTMX.
+ * Client-side scan history: keeps the last MAX_HISTORY scans in memory
+ * and renders them in the #scan-history panel. Cleared on page reload
+ * (server-side persistence is a post-M4 item per the risk register).
+ */
+const MAX_HISTORY = 5;
+const scanHistory = [];  // [{gtin, name, direction, qty, on_hand, ts}]
+
+function addToHistory(entry) {
+    scanHistory.unshift(entry);
+    if (scanHistory.length > MAX_HISTORY) scanHistory.pop();
+    renderHistory();
+}
+
+function renderHistory() {
+    const el = document.getElementById('scan-history');
+    if (scanHistory.length === 0) {
+        el.innerHTML = '<em style="color:#999;">No scans yet.</em>';
+        return;
+    }
+    el.innerHTML = scanHistory.map(e => {
+        const dirColor = e.direction === 'IN' ? 'green' : e.direction === 'OUT' ? '#c00' : '#555';
+        const label = e.name || e.gtin;
+        return `<div style="padding:0.3em 0; border-bottom:1px solid #eee; font-size:0.9em;">
+            <span style="color:${dirColor};font-weight:bold;">${e.direction}</span>
+            &nbsp;×${e.qty}&nbsp;
+            <strong>${label}</strong>
+            &nbsp;→&nbsp;on hand: <strong>${e.on_hand}</strong>
+            <span style="color:#999;float:right;">${e.ts}</span>
+        </div>`;
+    }).join('');
+}
+
+/**
+ * Handle barcode scanner input: Enter submits, arrow keys adjust custom qty.
  */
 document.getElementById('scan-input').addEventListener('keydown', function(evt) {
     if (evt.key === 'Enter') {
@@ -100,62 +133,66 @@ document.getElementById('scan-input').addEventListener('keydown', function(evt) 
 async function submitScan() {
     const scanInput = document.getElementById('scan-input');
     const gtin = scanInput.value.trim();
-    
-    if (!gtin) {
-        return;  // Ignore empty scans
-    }
-    
-    // Get form values
+
+    if (!gtin) return;
+
     const direction = document.querySelector('input[name="direction"]:checked').value;
     const locationId = document.querySelector('input[name="location_id"]').value;
     let qtyMultiplier = 1;
-    
+
     const selectedMode = document.querySelector('input[name="qty_multiplier"]:checked');
     if (selectedMode.value === 'custom') {
-        const customValue = parseInt(document.getElementById('custom-multiplier').value) || 1;
-        qtyMultiplier = customValue;
+        qtyMultiplier = parseInt(document.getElementById('custom-multiplier').value) || 1;
     } else {
         qtyMultiplier = parseInt(selectedMode.value) || 1;
     }
-    
+
     const payload = {
         gtin: gtin,
         direction: direction,
         qty_multiplier: qtyMultiplier,
         location_id: parseInt(locationId),
     };
-    
+
     try {
         const response = await fetch('/scan', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
-        
+
         if (response.ok) {
             const html = await response.text();
-            document.getElementById('scan-result').innerHTML = html;
+            const resultDiv = document.getElementById('scan-result');
+            resultDiv.innerHTML = html;
+
+            // Extract on_hand from the rendered partial via data attribute.
+            const onHandEl = resultDiv.querySelector('[data-on-hand]');
+            const nameEl   = resultDiv.querySelector('[data-item-name]');
+            addToHistory({
+                gtin:      gtin,
+                name:      nameEl      ? nameEl.dataset.itemName   : gtin,
+                direction: direction,
+                qty:       qtyMultiplier,
+                on_hand:   onHandEl    ? onHandEl.dataset.onHand   : '?',
+                ts:        new Date().toLocaleTimeString(),
+            });
         } else {
             const errorText = await response.text();
             let errorMessage = `Error ${response.status}`;
-            
             try {
                 const errorJson = JSON.parse(errorText);
                 errorMessage = errorJson.detail || errorMessage;
-            } catch (e) {
-                errorMessage = errorText || errorMessage;
-            }
-            
-            document.getElementById('scan-result').innerHTML = `<div style="color: red; padding: 1em; border: 1px solid red; border-radius: 4px; background: #ffe6e6;">${errorMessage}</div>`;
+            } catch (e) { errorMessage = errorText || errorMessage; }
+            document.getElementById('scan-result').innerHTML =
+                `<div style="color:red;padding:1em;border:1px solid red;border-radius:4px;background:#ffe6e6;">${errorMessage}</div>`;
         }
     } catch (error) {
         console.error('Fetch error:', error);
-        document.getElementById('scan-result').innerHTML = `<div style="color: red; padding: 1em;">Network error: ${error.message}</div>`;
+        document.getElementById('scan-result').innerHTML =
+            `<div style="color:red;padding:1em;">Network error: ${error.message}</div>`;
     }
-    
-    // Clear input and re-focus so the next scan is immediately ready.
+
     scanInput.value = '';
     scanInput.focus();
 }

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -1,0 +1,229 @@
+"""Integration tests for the M4 inventory view, export, and casepack flow.
+
+Tests the full HTTP layer for:
+- GET /inventory            — on-hand view
+- GET /export/items.csv     — items CSV
+- GET /export/movements.csv — movements CSV
+- Pack alias CRUD (POST /items/{id}/aliases, delete)
+- Auto-multiplier scan path (alias GTIN → canonical × multiplier)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response
+
+# ------------------------------------------------------------------ #
+# Inventory view                                                      #
+# ------------------------------------------------------------------ #
+
+
+def test_get_inventory_empty(client: TestClient) -> None:
+    """GET /inventory renders the page even with no movements."""
+    response = client.get("/inventory")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Inventory" in response.text
+
+
+@respx.mock
+def test_get_inventory_shows_scanned_item(client: TestClient) -> None:
+    """After a scan, /inventory lists the item with correct on-hand."""
+    gtin = "5555555555555"
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": gtin})
+    )
+    client.post("/scan", json={"gtin": gtin, "direction": "IN", "qty_multiplier": 5, "location_id": 1})
+
+    response = client.get("/inventory")
+    assert response.status_code == 200
+    assert gtin in response.text
+    assert "5" in response.text  # on_hand
+
+
+# ------------------------------------------------------------------ #
+# CSV exports                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_export_items_csv_empty(client: TestClient) -> None:
+    """GET /export/items.csv returns a valid CSV with headers only when empty."""
+    response = client.get("/export/items.csv")
+    assert response.status_code == 200
+    assert "text/csv" in response.headers["content-type"]
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+    text = response.content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    assert rows == []
+    assert "gtin" in (reader.fieldnames or [])
+    assert "on_hand_total" in (reader.fieldnames or [])
+
+
+@respx.mock
+def test_export_items_csv_contains_scanned_item(client: TestClient) -> None:
+    """After scanning, items.csv contains the item row with on_hand_total."""
+    gtin = "6666666666666"
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": gtin})
+    )
+    client.post("/scan", json={"gtin": gtin, "direction": "IN", "qty_multiplier": 3, "location_id": 1})
+
+    response = client.get("/export/items.csv")
+    text = response.content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["gtin"] == gtin
+    assert rows[0]["on_hand_total"] == "3"
+
+
+def test_export_movements_csv_empty(client: TestClient) -> None:
+    """GET /export/movements.csv returns valid CSV with headers only when empty."""
+    response = client.get("/export/movements.csv")
+    assert response.status_code == 200
+    assert "text/csv" in response.headers["content-type"]
+
+    text = response.content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    assert rows == []
+    assert "item_gtin" in (reader.fieldnames or [])
+    assert "delta" in (reader.fieldnames or [])
+
+
+@respx.mock
+def test_export_movements_csv_contains_movement(client: TestClient) -> None:
+    """After scanning, movements.csv contains the movement row."""
+    gtin = "7777777777777"
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": gtin})
+    )
+    client.post("/scan", json={"gtin": gtin, "direction": "IN", "qty_multiplier": 2, "location_id": 1})
+
+    response = client.get("/export/movements.csv")
+    text = response.content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["item_gtin"] == gtin
+    assert rows[0]["delta"] == "2"
+    assert rows[0]["direction"] == "IN"
+
+
+# ------------------------------------------------------------------ #
+# Pack alias CRUD via HTTP                                            #
+# ------------------------------------------------------------------ #
+
+
+@respx.mock
+def test_add_and_delete_pack_alias(client: TestClient) -> None:
+    """POST /items/{id}/aliases adds an alias; delete endpoint removes it."""
+    canonical_gtin = "8888888888888"
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{canonical_gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": canonical_gtin})
+    )
+    # Create canonical item via scan
+    client.post("/scan", json={"gtin": canonical_gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+
+    # Add alias
+    response = client.post(
+        "/items/1/aliases",
+        data={"alias_gtin": "0088888888888", "multiplier": "12", "label": "case-12"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+    # Alias should appear on enrich form
+    form = client.get("/items/1/enrich")
+    assert "0088888888888" in form.text
+    assert "case-12" in form.text
+
+    # Delete alias
+    del_response = client.post(
+        "/items/1/aliases/0088888888888/delete",
+        follow_redirects=False,
+    )
+    assert del_response.status_code == 303
+
+    # Alias should be gone
+    form_after = client.get("/items/1/enrich")
+    assert "0088888888888" not in form_after.text
+
+
+@respx.mock
+def test_add_alias_conflict_with_existing_item(client: TestClient) -> None:
+    """Cannot register an existing item GTIN as an alias (409)."""
+    gtin_a = "1000000000001"
+    gtin_b = "1000000000002"
+    for g in (gtin_a, gtin_b):
+        respx.get(f"https://world.openfoodfacts.org/api/v2/product/{g}.json").mock(
+            return_value=Response(200, json={"status": 0, "code": g})
+        )
+    client.post("/scan", json={"gtin": gtin_a, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+    client.post("/scan", json={"gtin": gtin_b, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+
+    # Try to register gtin_b as an alias of item 1
+    response = client.post(
+        "/items/1/aliases",
+        data={"alias_gtin": gtin_b, "multiplier": "6", "label": ""},
+    )
+    assert response.status_code == 409
+
+
+@respx.mock
+def test_delete_alias_not_found_returns_404(client: TestClient) -> None:
+    """Deleting a non-existent alias returns 404."""
+    gtin = "1000000000003"
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": gtin})
+    )
+    client.post("/scan", json={"gtin": gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+
+    response = client.post("/items/1/aliases/9999999999999/delete")
+    assert response.status_code == 404
+
+
+# ------------------------------------------------------------------ #
+# Auto-multiplier scan path (M4 exit criterion)                      #
+# ------------------------------------------------------------------ #
+
+
+@respx.mock
+def test_scan_alias_gtin_applies_auto_multiplier(client: TestClient) -> None:
+    """Scanning a case alias GTIN adds the multiplied eaches in one scan.
+
+    M4 exit criterion: scanning a case barcode for a known alias adds
+    the multiplied eaches without operator input.
+    """
+    canonical_gtin = "2000000000001"
+    alias_gtin = "0020000000001"
+
+    # Create canonical item
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{canonical_gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": canonical_gtin})
+    )
+    client.post("/scan", json={"gtin": canonical_gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+
+    # Register alias (case of 12)
+    client.post(
+        "/items/1/aliases",
+        data={"alias_gtin": alias_gtin, "multiplier": "12", "label": "case-12"},
+    )
+
+    # Scan the alias GTIN — should add 12 eaches (not 1)
+    response = client.post(
+        "/scan",
+        json={"gtin": alias_gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1},
+    )
+    assert response.status_code == 200
+    # on_hand should now be 13 (1 initial + 12 from alias scan)
+    assert ">13<" in response.text or "13" in response.text
+    assert "auto-multiplied" in response.text

--- a/tests/unit/test_packs.py
+++ b/tests/unit/test_packs.py
@@ -1,0 +1,102 @@
+"""Unit tests for pack alias resolution (inv/core/packs.py).
+
+Tests the AliasRepository and resolve_alias() using the real SQLite
+session fixture so alias FK constraints are exercised.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from inv.core.packs import resolve_alias
+from inv.storage.orm import Item
+from inv.storage.repositories import AliasRepository, ItemRepository
+
+
+def _make_item(session: Session, gtin: str, name: str | None = None) -> Item:
+    repo = ItemRepository(session)
+    item = repo.create(gtin, name=name, needs_review=False, source="test")
+    session.commit()
+    return item
+
+
+# ------------------------------------------------------------------ #
+# AliasRepository                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_alias_repo_create_and_get(session: Session) -> None:
+    """Creating an alias and fetching it by GTIN round-trips correctly."""
+    item = _make_item(session, "1234567890123", "Canonical Item")
+    repo = AliasRepository(session)
+    repo.create(gtin="0012345678901", item_id=item.id, multiplier=12, label="case-12")
+    session.commit()
+
+    fetched = repo.get_by_gtin("0012345678901")
+    assert fetched is not None
+    assert fetched.multiplier == 12
+    assert fetched.label == "case-12"
+    assert fetched.item_id == item.id
+
+
+def test_alias_repo_list_for_item(session: Session) -> None:
+    """list_for_item returns all aliases registered for a given item."""
+    item = _make_item(session, "1111111111111")
+    repo = AliasRepository(session)
+    repo.create(gtin="0011111111111", item_id=item.id, multiplier=6, label="inner-6")
+    repo.create(gtin="0021111111111", item_id=item.id, multiplier=24, label="case-24")
+    session.commit()
+
+    aliases = repo.list_for_item(item.id)
+    assert len(aliases) == 2
+    gtins = {a.gtin for a in aliases}
+    assert "0011111111111" in gtins
+    assert "0021111111111" in gtins
+
+
+def test_alias_repo_delete(session: Session) -> None:
+    """delete() removes the alias and returns True; returns False if missing."""
+    item = _make_item(session, "2222222222222")
+    repo = AliasRepository(session)
+    repo.create(gtin="0022222222222", item_id=item.id, multiplier=12)
+    session.commit()
+
+    assert repo.delete("0022222222222") is True
+    session.commit()
+    assert repo.get_by_gtin("0022222222222") is None
+
+    assert repo.delete("0022222222222") is False
+
+
+def test_alias_repo_get_missing_returns_none(session: Session) -> None:
+    """get_by_gtin returns None for an unregistered GTIN."""
+    repo = AliasRepository(session)
+    assert repo.get_by_gtin("9999999999999") is None
+
+
+# ------------------------------------------------------------------ #
+# resolve_alias                                                       #
+# ------------------------------------------------------------------ #
+
+
+def test_resolve_alias_no_match(session: Session) -> None:
+    """resolve_alias returns the original GTIN unchanged when no alias exists."""
+    resolution = resolve_alias(session, "3333333333333")
+    assert resolution.canonical_gtin == "3333333333333"
+    assert resolution.multiplier == 1
+    assert resolution.was_alias is False
+    assert resolution.alias_label is None
+
+
+def test_resolve_alias_hit(session: Session) -> None:
+    """resolve_alias returns the canonical GTIN + multiplier when an alias matches."""
+    item = _make_item(session, "4444444444444", "Canonical Product")
+    repo = AliasRepository(session)
+    repo.create(gtin="0044444444444", item_id=item.id, multiplier=12, label="case-12")
+    session.commit()
+
+    resolution = resolve_alias(session, "0044444444444")
+    assert resolution.canonical_gtin == "4444444444444"
+    assert resolution.multiplier == 12
+    assert resolution.was_alias is True
+    assert resolution.alias_label == "case-12"


### PR DESCRIPTION
## Summary

Implements M4 in full against the exit criteria in DEVELOPMENT_PLAN.md §9.

- **`AliasRepository`** (`storage/repositories.py`) — get_by_gtin, list_for_item, create, delete over the `pack_alias` table
- **`resolve_alias()`** (`core/packs.py`) — looks up a scanned GTIN in `pack_alias` before the provider chain; returns `AliasResolution` with canonical GTIN + multiplier; pure DB read, no network
- **Auto-multiplier scan path** — `POST /scan` calls `resolve_alias` first; on a match, the canonical GTIN is used for item lookup/creation and the alias multiplier overrides the operator's `qty_multiplier`; `scan_result.html` shows an "auto-multiplied" badge
- **Pack alias CRUD** in the enrichment form:
  - `POST /items/{id}/aliases` — add alias; 409 if alias GTIN conflicts with existing item or alias
  - `POST /items/{id}/aliases/{gtin}/delete` — remove alias; PRG redirect
  - `GET /items/{id}/enrich` now passes alias list to template; form renders alias table + add form
- **`GET /inventory`** — on-hand view querying `inventory_view JOIN item JOIN location`; shows on_hand, last movement timestamp, needs_review badge, Enrich link; export links in header
- **`GET /export/items.csv`** — all items with `on_hand_total` (summed across locations); UTF-8 BOM for Excel
- **`GET /export/movements.csv`** — full movement log with denormalised item_gtin/item_name/location_name
- **Scan history panel** — `scan.html` now renders the last 5 scans client-side per session (server-side persistence deferred per risk register §11)
- `inventory_router` + `export_router` registered in `main.py`

## Verification

```
uv run pytest          # 79 passed (was 63)
uv run ruff check inv tests   # clean
uv run mypy inv        # clean
```

## M4 exit criteria

| Criterion | Status |
|---|---|
| Scanning case barcode for known alias adds multiplied eaches in one scan | ✓ `test_scan_alias_gtin_applies_auto_multiplier` |
| CSV exports open cleanly in a spreadsheet (UTF-8 BOM, correct headers) | ✓ `test_export_items_csv_*` / `test_export_movements_csv_*` |
| `/inventory` shows per-item on-hand + last movement | ✓ `test_get_inventory_shows_scanned_item` |
| Pack alias add/delete round-trips via HTTP | ✓ `test_add_and_delete_pack_alias` |
| Conflict guards prevent invalid alias registration | ✓ `test_add_alias_conflict_with_existing_item` |

## Commit layout

1. `feat(M4)` — `AliasRepository` + `resolve_alias`
2. `feat(M4)` — alias auto-multiplier in scan path + alias CRUD in enrich form
3. `feat(M4)` — `/inventory` view, CSV exports, router registration
4. `feat(M4)` — scan history panel (client-side, last 5 scans)
5. `test(M4)` — 6 unit + 10 integration tests

## Not in this PR

- Server-side scan history persistence (risk register §11, not scoped in any milestone)
- `item.pack_size` edit in enrichment form (the column exists in the schema; editing it is an M4+ nice-to-have not called for in the exit criteria)