### PR TITLE
fix(M4): hardening — zero-stock filter, dynamic test IDs, health router (#18-#20)

### DIFF
--- a/inv/api/routes_health.py
+++ b/inv/api/routes_health.py
@@ -1,0 +1,26 @@
+"""Health check and version endpoints.
+
+These are intentionally thin — they live outside the database path so
+they can be called by load-balancers, monitoring agents, and ``pipx``
+post-install checks without any DB dependency.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from inv import __version__
+
+router = APIRouter(tags=["system"])
+
+
+@router.get("/health")
+async def health() -> dict:
+    """Liveness probe. Returns 200 as long as the process is running."""
+    return {"status": "ok", "version": __version__}
+
+
+@router.get("/version")
+async def version() -> dict:
+    """Return the installed package version."""
+    return {"version": __version__}

--- a/inv/api/routes_inventory.py
+++ b/inv/api/routes_inventory.py
@@ -28,9 +28,10 @@ async def get_inventory(
     """Render the inventory on-hand view.
 
     Queries the ``inventory_view`` SQL VIEW (created by the baseline
-    migration) and joins item + location names. Returns rows only where
-    ``on_hand != 0`` by default so zero-stock items don't clutter the
-    view. The last movement timestamp is fetched per item/location pair.
+    migration) and joins item + location names. Only rows where
+    ``on_hand > 0`` are returned — fully depleted items are not shown
+    here (they remain visible on ``/items`` and in the CSV export).
+    The last movement timestamp is fetched per item/location pair.
     """
     rows = session.execute(
         text("""
@@ -52,6 +53,7 @@ async def get_inventory(
             FROM inventory_view v
             JOIN item     i ON i.id = v.item_id
             JOIN location l ON l.id = v.location_id
+            WHERE v.on_hand > 0
             ORDER BY l.name, i.name NULLS LAST, i.gtin
         """)
     ).mappings().all()

--- a/inv/main.py
+++ b/inv/main.py
@@ -6,6 +6,7 @@ from fastapi.responses import HTMLResponse
 
 from inv import __version__
 from inv.api.routes_export import router as export_router
+from inv.api.routes_health import router as health_router
 from inv.api.routes_inventory import router as inventory_router
 from inv.api.routes_items import router as items_router
 from inv.api.routes_scan import router as scan_router
@@ -47,27 +48,13 @@ def create_app(settings: Settings) -> FastAPI:
     # Serve vendored HTMX / Alpine / Pico from inv/web/static/.
     mount_static(app)
 
-    @app.get("/health", tags=["system"])
-    async def health() -> dict:
-        """Health check endpoint."""
-        return {"status": "ok", "version": __version__}
-
-    @app.get("/version", tags=["system"])
-    async def version() -> dict:
-        """Version endpoint."""
-        return {"version": __version__}
-
     @app.get("/", response_class=HTMLResponse, tags=["system"])
     async def index(request: Request) -> HTMLResponse:
-        """Render the base template as the M1 landing page.
-
-        M2 will replace this with the scan page. For now the page exists
-        so that `/` is a valid entry point, static assets are exercised,
-        and we don't 404 the user on first visit.
-        """
+        """Render the base template as the landing page."""
         return templates.TemplateResponse(request, "base.html", {"version": __version__})
 
-    # Register routers
+    # Register all routers — one line per module, in dependency order.
+    app.include_router(health_router)
     app.include_router(scan_router)
     app.include_router(items_router)
     app.include_router(inventory_router)

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -16,6 +16,22 @@ import io
 import respx
 from fastapi.testclient import TestClient
 from httpx import Response
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session
+
+from inv.storage.orm import Item as ItemORM
+
+
+def _item_id_for_gtin(engine: Engine, gtin: str) -> int:
+    """Return the database ID for a given GTIN.
+
+    Used instead of assuming ``id=1`` so tests are resilient to
+    ordering and fixture changes (issue #19).
+    """
+    with Session(engine) as sess:
+        item = sess.query(ItemORM).filter_by(gtin=gtin).first()
+        assert item is not None, f"No item found for GTIN {gtin}"
+        return int(item.id)
 
 # ------------------------------------------------------------------ #
 # Inventory view                                                      #
@@ -43,6 +59,21 @@ def test_get_inventory_shows_scanned_item(client: TestClient) -> None:
     assert response.status_code == 200
     assert gtin in response.text
     assert "5" in response.text  # on_hand
+
+
+@respx.mock
+def test_get_inventory_hides_zero_stock_items(client: TestClient) -> None:
+    """After full depletion, /inventory does not show the item (issue #18)."""
+    gtin = "5555555555556"
+    respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
+        return_value=Response(200, json={"status": 0, "code": gtin})
+    )
+    client.post("/scan", json={"gtin": gtin, "direction": "IN", "qty_multiplier": 5, "location_id": 1})
+    client.post("/scan", json={"gtin": gtin, "direction": "OUT", "qty_multiplier": 5, "location_id": 1})
+
+    response = client.get("/inventory")
+    assert response.status_code == 200
+    assert gtin not in response.text
 
 
 # ------------------------------------------------------------------ #
@@ -124,42 +155,43 @@ def test_export_movements_csv_contains_movement(client: TestClient) -> None:
 
 
 @respx.mock
-def test_add_and_delete_pack_alias(client: TestClient) -> None:
+def test_add_and_delete_pack_alias(client: TestClient, engine: Engine) -> None:
     """POST /items/{id}/aliases adds an alias; delete endpoint removes it."""
     canonical_gtin = "8888888888888"
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{canonical_gtin}.json").mock(
         return_value=Response(200, json={"status": 0, "code": canonical_gtin})
     )
-    # Create canonical item via scan
+    # Create canonical item via scan then resolve its DB id (issue #19)
     client.post("/scan", json={"gtin": canonical_gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+    item_id = _item_id_for_gtin(engine, canonical_gtin)
 
     # Add alias
     response = client.post(
-        "/items/1/aliases",
+        f"/items/{item_id}/aliases",
         data={"alias_gtin": "0088888888888", "multiplier": "12", "label": "case-12"},
         follow_redirects=False,
     )
     assert response.status_code == 303
 
     # Alias should appear on enrich form
-    form = client.get("/items/1/enrich")
+    form = client.get(f"/items/{item_id}/enrich")
     assert "0088888888888" in form.text
     assert "case-12" in form.text
 
     # Delete alias
     del_response = client.post(
-        "/items/1/aliases/0088888888888/delete",
+        f"/items/{item_id}/aliases/0088888888888/delete",
         follow_redirects=False,
     )
     assert del_response.status_code == 303
 
     # Alias should be gone
-    form_after = client.get("/items/1/enrich")
+    form_after = client.get(f"/items/{item_id}/enrich")
     assert "0088888888888" not in form_after.text
 
 
 @respx.mock
-def test_add_alias_conflict_with_existing_item(client: TestClient) -> None:
+def test_add_alias_conflict_with_existing_item(client: TestClient, engine: Engine) -> None:
     """Cannot register an existing item GTIN as an alias (409)."""
     gtin_a = "1000000000001"
     gtin_b = "1000000000002"
@@ -169,25 +201,26 @@ def test_add_alias_conflict_with_existing_item(client: TestClient) -> None:
         )
     client.post("/scan", json={"gtin": gtin_a, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
     client.post("/scan", json={"gtin": gtin_b, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+    item_a_id = _item_id_for_gtin(engine, gtin_a)
 
-    # Try to register gtin_b as an alias of item 1
     response = client.post(
-        "/items/1/aliases",
+        f"/items/{item_a_id}/aliases",
         data={"alias_gtin": gtin_b, "multiplier": "6", "label": ""},
     )
     assert response.status_code == 409
 
 
 @respx.mock
-def test_delete_alias_not_found_returns_404(client: TestClient) -> None:
+def test_delete_alias_not_found_returns_404(client: TestClient, engine: Engine) -> None:
     """Deleting a non-existent alias returns 404."""
     gtin = "1000000000003"
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
         return_value=Response(200, json={"status": 0, "code": gtin})
     )
     client.post("/scan", json={"gtin": gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+    item_id = _item_id_for_gtin(engine, gtin)
 
-    response = client.post("/items/1/aliases/9999999999999/delete")
+    response = client.post(f"/items/{item_id}/aliases/9999999999999/delete")
     assert response.status_code == 404
 
 
@@ -197,7 +230,7 @@ def test_delete_alias_not_found_returns_404(client: TestClient) -> None:
 
 
 @respx.mock
-def test_scan_alias_gtin_applies_auto_multiplier(client: TestClient) -> None:
+def test_scan_alias_gtin_applies_auto_multiplier(client: TestClient, engine: Engine) -> None:
     """Scanning a case alias GTIN adds the multiplied eaches in one scan.
 
     M4 exit criterion: scanning a case barcode for a known alias adds
@@ -206,15 +239,16 @@ def test_scan_alias_gtin_applies_auto_multiplier(client: TestClient) -> None:
     canonical_gtin = "2000000000001"
     alias_gtin = "0020000000001"
 
-    # Create canonical item
+    # Create canonical item; resolve DB id without assuming it is 1 (issue #19)
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{canonical_gtin}.json").mock(
         return_value=Response(200, json={"status": 0, "code": canonical_gtin})
     )
     client.post("/scan", json={"gtin": canonical_gtin, "direction": "IN", "qty_multiplier": 1, "location_id": 1})
+    item_id = _item_id_for_gtin(engine, canonical_gtin)
 
     # Register alias (case of 12)
     client.post(
-        "/items/1/aliases",
+        f"/items/{item_id}/aliases",
         data={"alias_gtin": alias_gtin, "multiplier": "12", "label": "case-12"},
     )
 


### PR DESCRIPTION
## Summary

Three post-merge hardening fixes from the M4 validator audit. No blockers were found in M4 — these are the cleanup items before M5 starts.

- **#18** `/inventory` SQL now filters `WHERE v.on_hand > 0`. Fully depleted items no longer appear in the working view (they remain visible on `/items` and in the CSV export). Docstring updated to match. New test asserts depletion → item disappears from `/inventory`.
- **#19** `test_export.py` no longer hardcodes `/items/1/aliases`. New `_item_id_for_gtin(engine, gtin)` helper resolves the real DB id after each scan. All 4 alias test functions accept the `engine` fixture and use the helper. Tests are now order-independent.
- **#20** `routes_health.py` (0-byte stub since M1) now contains a real `APIRouter` with `/health` and `/version` handlers. `create_app()` registers it via `app.include_router(health_router)` alongside all other routers. Inline closures removed from `main.py`. Matches `DEVELOPMENT_PLAN.md` §7 layout.

## Verification

```
pytest          # 80 passed (was 79; +1 depletion test)
ruff check      # clean
mypy inv        # clean
```

## Commit layout

1. `fix(M4,#18,#19)` — inventory SQL + dynamic test IDs (both in `test_export.py`)
2. `fix(M4,#20)` — routes_health.py populated; inline closures removed from main.py

## Not in this PR

Opportunities from the audit (empty `scan_unknown.attempted_providers` tuple, `scan.html` comment cleanup, `was_alias=False` test, inline `ItemRepository` import in `routes_scan.py`) are deferred — they don't block M5 and are better filed as pre-M5 tickets if the team wants them.

Closes #18, closes #19, closes #20