### PR TITLE
fix(#22): surface attempted_providers from ChainRunner into ScanUnknownEvent

### DIFF
--- a/inv/api/routes_scan.py
+++ b/inv/api/routes_scan.py
@@ -90,9 +90,12 @@ async def post_scan(
     is_new_gtin = item_repo.get_by_gtin(effective_gtin) is None
 
     lookup_result = None
+    attempted_providers: tuple[str, ...] = ()
     if is_new_gtin:
         chain = ChainRunner(session)
-        lookup_result = await chain.run(effective_gtin)
+        chain_result = await chain.run(effective_gtin)
+        lookup_result = chain_result.result
+        attempted_providers = chain_result.attempted_providers
 
     # Step 3: record the movement.
     try:
@@ -105,6 +108,7 @@ async def post_scan(
             actor=req.actor,
             note=req.note,
             lookup_result=lookup_result,
+            attempted_providers=attempted_providers,
         )
     except LocationNotFoundError as e:
         raise HTTPException(

--- a/inv/core/services.py
+++ b/inv/core/services.py
@@ -92,6 +92,7 @@ def record_scan(
     actor: str | None = None,
     note: str | None = None,
     lookup_result: object | None = None,
+    attempted_providers: tuple[str, ...] = (),
 ) -> ScanResult:
     """Record a barcode scan and update inventory.
 
@@ -116,6 +117,11 @@ def record_scan(
             newly-created item the fields are applied immediately so the
             item is enriched in the same transaction as the movement.
             Pass ``None`` to leave the item as a plain stub.
+        attempted_providers: Ordered tuple of provider names tried by
+            ``ChainRunner`` before giving up. Passed through to
+            ``ScanUnknownEvent`` so subscribers receive accurate
+            diagnostics. Empty tuple on cache hits or when the caller
+            did not run the chain (e.g. re-scans of known GTINs).
 
     Returns:
         ScanResult with movement details and current on-hand.
@@ -198,7 +204,7 @@ def record_scan(
                 "record_scan",
                 event=ScanUnknownEvent(
                     gtin=gtin,
-                    attempted_providers=(),
+                    attempted_providers=attempted_providers,
                 ),
             )
 

--- a/inv/lookup/chain.py
+++ b/inv/lookup/chain.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import NamedTuple
 
 from sqlalchemy.orm import Session
 
@@ -34,6 +35,28 @@ from inv.lookup.upcitemdb import UPCitemdbProvider
 log = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 3.0  # seconds per provider
+
+
+class ChainResult(NamedTuple):
+    """Return value of :meth:`ChainRunner.run`.
+
+    Carries both the lookup outcome and the list of network providers
+    that were actually attempted (in order), so callers can surface
+    accurate diagnostic data in ``ScanUnknownEvent.attempted_providers``
+    rather than always passing an empty tuple.
+
+    Attributes:
+        result: A populated :class:`~inv.lookup.base.ProviderResult` on
+            a hit, or ``None`` if every provider missed.
+        attempted_providers: Tuple of provider ``name`` strings for every
+            network provider that was called (skipped providers, e.g.
+            OpenLibrary on a non-ISBN GTIN, are still included because
+            they were invoked — they just returned ``None`` immediately).
+            Empty tuple on a cache hit (no network providers were tried).
+    """
+
+    result: ProviderResult | None
+    attempted_providers: tuple[str, ...]
 
 
 class ChainRunner:
@@ -71,18 +94,21 @@ class ChainRunner:
             *(extra_providers or []),
         ]
 
-    async def run(self, gtin: str) -> ProviderResult | None:
+    async def run(self, gtin: str) -> ChainResult:
         """Look up a GTIN through the full chain.
 
-        Returns the first successful ``ProviderResult``, or ``None`` if
-        every provider misses. Cache hits are returned immediately without
-        touching network providers.
+        Returns a :class:`ChainResult` containing the first successful
+        ``ProviderResult`` (or ``None`` on total miss) and the ordered
+        tuple of network provider names that were attempted.
+
+        Cache hits short-circuit the network providers entirely;
+        ``attempted_providers`` will be an empty tuple in that case.
         """
         # Step 0: local cache (no timeout — synchronous SQLite)
         cached = await self._cache.lookup(gtin)
         if cached is not None:
             log.debug("cache hit for %s (provider=%s)", gtin, cached.provider)
-            return cached
+            return ChainResult(result=cached, attempted_providers=())
 
         # Steps 1-4: network providers with per-provider timeout
         attempted: list[str] = []
@@ -110,10 +136,10 @@ class ChainRunner:
                 # Write through to cache
                 self._cache.store(result)
                 self._session.commit()
-                return result
+                return ChainResult(result=result, attempted_providers=tuple(attempted))
 
         log.debug("all providers missed for gtin=%s attempted=%s", gtin, attempted)
-        return None
+        return ChainResult(result=None, attempted_providers=tuple(attempted))
 
     @property
     def provider_names(self) -> list[str]:

--- a/tests/integration/test_enrich_flow.py
+++ b/tests/integration/test_enrich_flow.py
@@ -234,3 +234,6 @@ def test_scan_unknown_signal_fired_on_all_miss(client: TestClient) -> None:
 
     assert len(received) == 1
     assert received[0].gtin == gtin
+    # attempted_providers must now be populated — not an empty tuple (issue #22)
+    assert len(received[0].attempted_providers) > 0
+    assert "openfoodfacts" in received[0].attempted_providers

--- a/tests/unit/test_chain.py
+++ b/tests/unit/test_chain.py
@@ -270,7 +270,11 @@ def test_cache_store_and_hit(session: Session) -> None:
 
 @respx.mock
 async def test_chain_returns_first_hit(session: Session) -> None:
-    """ChainRunner stops at the first provider hit (OFF) and writes to cache."""
+    """ChainRunner stops at the first provider hit (OFF) and writes to cache.
+
+    ChainResult.result is the ProviderResult; attempted_providers contains
+    every provider called up to and including the hit.
+    """
     gtin = "3017620422003"
     payload = _load("openfoodfacts_hit.json")
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
@@ -278,11 +282,13 @@ async def test_chain_returns_first_hit(session: Session) -> None:
     )
 
     chain = ChainRunner(session)
-    result = await chain.run(gtin)
+    chain_result = await chain.run(gtin)
 
-    assert result is not None
-    assert result.provider == "openfoodfacts"
-    assert result.name == "Nutella"
+    assert chain_result.result is not None
+    assert chain_result.result.provider == "openfoodfacts"
+    assert chain_result.result.name == "Nutella"
+    # OFF is the first network provider; attempted should contain it
+    assert "openfoodfacts" in chain_result.attempted_providers
 
     # Verify written to cache
     cache = CacheProvider(session)
@@ -293,7 +299,7 @@ async def test_chain_returns_first_hit(session: Session) -> None:
 
 @respx.mock
 async def test_chain_cache_hit_skips_network(session: Session) -> None:
-    """A pre-seeded cache entry is returned without any network provider being called."""
+    """A pre-seeded cache entry is returned; attempted_providers is empty."""
     gtin = "3017620422003"
 
     # Pre-seed the cache
@@ -305,31 +311,38 @@ async def test_chain_cache_hit_skips_network(session: Session) -> None:
 
     # No network routes registered — if the chain hits the network, respx will raise
     chain = ChainRunner(session)
-    result = await chain.run(gtin)
+    chain_result = await chain.run(gtin)
 
-    assert result is not None
-    assert result.name == "Cached Nutella"
+    assert chain_result.result is not None
+    assert chain_result.result.name == "Cached Nutella"
+    # Cache hit — no network providers were tried
+    assert chain_result.attempted_providers == ()
 
 
 @respx.mock
 async def test_chain_all_miss_returns_none(session: Session) -> None:
-    """ChainRunner returns None when every provider misses."""
+    """ChainRunner returns result=None with all provider names on total miss."""
     gtin = "0000000000000"
 
     # OFF miss
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
         return_value=Response(200, json={"status": 0, "code": gtin})
     )
-    # Open Library: not an ISBN — skipped automatically
+    # Open Library: not an ISBN — skipped automatically (but still attempted)
     # OpenGTINdb: always None
-    # UPCitemdb: 13-digit non-zero-prefixed — skipped
+    # UPCitemdb: 13-digit non-zero-prefixed — skipped (but still attempted)
     chain = ChainRunner(session)
-    result = await chain.run(gtin)
-    assert result is None
+    chain_result = await chain.run(gtin)
+
+    assert chain_result.result is None
+    # All four network providers were attempted even though most skip internally
+    assert chain_result.attempted_providers == (
+        "openfoodfacts", "openlibrary", "opengtindb", "upcitemdb"
+    )
 
 
 async def test_chain_provider_timeout_returns_none(session: Session) -> None:
-    """A provider that times out is swallowed and the chain continues."""
+    """A provider that times out is swallowed; its name appears in attempted_providers."""
     import asyncio
 
     async def _slow_lookup(_gtin: str) -> ProviderResult | None:
@@ -342,10 +355,9 @@ async def test_chain_provider_timeout_returns_none(session: Session) -> None:
         async def lookup(self, gtin: str) -> ProviderResult | None:
             return await _slow_lookup(gtin)
 
-    # Chain with only the slow provider and a tiny timeout
     chain = ChainRunner(session, provider_timeout=0.01, extra_providers=[SlowProvider()])
-    # Override built-in providers with empty list for this test
     chain._network_providers = [SlowProvider()]
 
-    result = await chain.run("1234567890123")
-    assert result is None
+    chain_result = await chain.run("1234567890123")
+    assert chain_result.result is None
+    assert chain_result.attempted_providers == ("slow",)


### PR DESCRIPTION
## Summary

Closes #22.

`ScanUnknownEvent.attempted_providers` was always an empty tuple because `ChainRunner.run()` built the attempted list internally and discarded it before returning. Any future plugin subscribing to `scan.unknown` would receive `attempted_providers=()` — "we tried nothing" — which is incorrect and would be confusing to debug.

**Root cause:** `ChainRunner.run()` returned `ProviderResult | None` with no way to surface the attempted list to the caller.

**Fix:** introduce `ChainResult(NamedTuple)` with two fields:

```python
class ChainResult(NamedTuple):
    result: ProviderResult | None
    attempted_providers: tuple[str, ...]
```

`ChainRunner.run()` now returns `ChainResult` in all three cases:
- Cache hit → `result=<ProviderResult>, attempted_providers=()`
- Network hit → `result=<ProviderResult>, attempted_providers=(...up to and including the hit...)`
- Total miss → `result=None, attempted_providers=(...all four provider names...)`

`routes_scan.py` unpacks the result before passing to `record_scan`. `record_scan` accepts `attempted_providers` as a kwarg and passes it straight through to `ScanUnknownEvent`.

## Verification

```
uv run pytest          # 80 passed
uv run ruff check inv tests   # clean
uv run mypy inv        # clean
```

## Tests updated

- `test_chain_returns_first_hit` — asserts `result` and `attempted_providers` contains OFF
- `test_chain_cache_hit_skips_network` — asserts `attempted_providers == ()`
- `test_chain_all_miss_returns_none` — asserts all four provider names present in order
- `test_chain_provider_timeout_returns_none` — asserts timed-out provider name present
- `test_scan_unknown_signal_fired_on_all_miss` — asserts `attempted_providers` is non-empty and contains `"openfoodfacts"` (issue #22 acceptance criterion)