### PR TITLE
test: anchor provider fixture path in conftest; document fresh_settings intent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,10 @@ free to land it; otherwise ignore the red X.
 - **Smoke tests** in `tests/smoke/` — optional Playwright/keystroke tests.
 
 Use `respx` for mocking HTTPX calls (provider lookups). Recorded fixtures
-live under `tests/fixtures/providers/` so the suite runs offline.
+live under `tests/fixtures/providers/` so the suite runs offline. Access
+them via the `provider_fixtures_dir` session fixture from `conftest.py`
+— never construct a `Path(__file__).parent...` chain pointing at that
+directory from inside a test file (see Gotchas below).
 
 ### Example test
 
@@ -234,6 +237,16 @@ These are in the codebase because a previous PR fixed them. Don't re-break them.
   upsert-with-kwargs that overwrites fields.
 - **CORS `allow_credentials=True` + `allow_origins=["*"]` is a spec
   violation.** Browsers reject the combo. Keep origins explicit.
+- **Don't use `__file__`-relative paths to reach `tests/fixtures/` from
+  inside a test file.** Use the `provider_fixtures_dir` session fixture
+  from `tests/conftest.py` instead. `conftest.py`'s location relative to
+  `tests/` is guaranteed by pytest's discovery rules; a
+  `Path(__file__).parent.parent / ...` chain silently resolves to the
+  wrong directory if the test file is ever moved to a different depth.
+  If a test fixture file needs a local fixture for intentionally isolated
+  state (e.g. `fresh_settings` in `test_migrations.py`), add a comment
+  explaining why it is local so the next contributor doesn't move it to
+  `conftest.py` by mistake.
 
 ## Milestones & Scope
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,13 @@ def app(settings: Settings, engine: Engine):  # type: ignore[no-untyped-def]
 def client(app) -> TestClient:  # type: ignore[no-untyped-def]
     """Create FastAPI test client."""
     return TestClient(app)
+
+
+@pytest.fixture(scope="session")
+def provider_fixtures_dir() -> Path:
+    """Absolute path to tests/fixtures/providers.
+
+    Anchored to conftest.py rather than individual test files so the path
+    remains correct regardless of where a test file lives in the tree.
+    """
+    return Path(__file__).parent / "fixtures" / "providers"

--- a/tests/integration/test_enrich_flow.py
+++ b/tests/integration/test_enrich_flow.py
@@ -17,12 +17,6 @@ import respx
 from fastapi.testclient import TestClient
 from httpx import Response
 
-FIXTURES = Path(__file__).parent.parent / "fixtures" / "providers"
-
-
-def _load(name: str) -> dict:
-    return json.loads((FIXTURES / name).read_text())
-
 
 # ------------------------------------------------------------------ #
 # Item list                                                           #
@@ -118,10 +112,12 @@ def test_post_enrich_form_unknown_id_returns_404(client: TestClient) -> None:
 
 
 @respx.mock
-def test_scan_unknown_gtin_enriched_from_off(client: TestClient) -> None:
+def test_scan_unknown_gtin_enriched_from_off(
+    client: TestClient, provider_fixtures_dir: Path
+) -> None:
     """First scan of a food GTIN populates name/brand from Open Food Facts."""
     gtin = "3017620422003"
-    payload = _load("openfoodfacts_hit.json")
+    payload = json.loads((provider_fixtures_dir / "openfoodfacts_hit.json").read_text())
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(
         return_value=Response(200, json=payload)
     )
@@ -136,7 +132,9 @@ def test_scan_unknown_gtin_enriched_from_off(client: TestClient) -> None:
 
 
 @respx.mock
-def test_scan_isbn_enriched_from_openlibrary(client: TestClient) -> None:
+def test_scan_isbn_enriched_from_openlibrary(
+    client: TestClient, provider_fixtures_dir: Path
+) -> None:
     """First scan of an ISBN-13 populates title/author from Open Library."""
     isbn = "9780140328721"
     # OFF will miss (not an ISBN in their DB — simulate miss)
@@ -144,7 +142,7 @@ def test_scan_isbn_enriched_from_openlibrary(client: TestClient) -> None:
         return_value=Response(200, json={"status": 0, "code": isbn})
     )
     # Open Library hit
-    payload = _load("openlibrary_hit.json")
+    payload = json.loads((provider_fixtures_dir / "openlibrary_hit.json").read_text())
     respx.get("https://openlibrary.org/api/books").mock(
         return_value=Response(200, json=payload)
     )
@@ -180,10 +178,12 @@ def test_scan_all_providers_miss_creates_needs_review_stub(client: TestClient) -
 
 
 @respx.mock
-def test_rescan_known_gtin_skips_chain(client: TestClient) -> None:
+def test_rescan_known_gtin_skips_chain(
+    client: TestClient, provider_fixtures_dir: Path
+) -> None:
     """Re-scanning a known GTIN does not hit the network (chain is bypassed)."""
     gtin = "3017620422003"
-    payload = _load("openfoodfacts_hit.json")
+    payload = json.loads((provider_fixtures_dir / "openfoodfacts_hit.json").read_text())
 
     # First scan — chain runs
     respx.get(f"https://world.openfoodfacts.org/api/v2/product/{gtin}.json").mock(

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -21,7 +21,12 @@ EXPECTED_VIEWS = {"inventory_view"}
 
 @pytest.fixture
 def fresh_settings() -> Settings:
-    """Settings pointing at a fresh temporary SQLite file."""
+    """Settings pointing at a fresh temporary SQLite file.
+
+    Intentionally defined here rather than in conftest.py: the shared ``engine``
+    fixture pre-seeds a ``Main`` location, which would interfere with downgrade
+    tests that must start from a completely bare database.
+    """
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
         return Settings(database_url=f"sqlite:///{Path(f.name)}")
 


### PR DESCRIPTION
## Summary

Closes #25

- Removes the fragile `__file__`-relative `FIXTURES` constant from `tests/integration/test_enrich_flow.py` and replaces it with a session-scoped `provider_fixtures_dir` fixture in `tests/conftest.py`. Because `conftest.py`'s location relative to `tests/fixtures/` is enforced by pytest's own discovery rules, the path remains correct if any test file is ever moved to a different directory depth.
- Adds an explanatory comment to the local `fresh_settings` fixture in `tests/unit/test_migrations.py` to make clear it is intentionally _not_ in `conftest.py` — the shared `engine` fixture pre-seeds a `Main` location which would interfere with downgrade tests that require a completely bare database.
- Updates `CONTRIBUTING.md`: the Testing section now directs contributors to use `provider_fixtures_dir`; the Gotchas section documents both the `__file__`-path anti-pattern and the intentional-local-fixture pattern so neither mistake gets repeated.

## Verification

```
80 passed in 4.46s
```

No behaviour changes — structural fix, explanatory comments, and documentation.